### PR TITLE
[1.1.0] Added trigger management — CLI, loader, Rake hooks, introspection

### DIFF
--- a/lib/arfi.rb
+++ b/lib/arfi.rb
@@ -4,6 +4,8 @@ require_relative 'arfi/version'
 require_relative 'arfi/errors'
 require_relative 'arfi/cli'
 require_relative 'arfi/commands/f_idx'
+require_relative 'arfi/commands/triggers'
+require 'arfi/sql_trigger_loader'
 require 'arfi/extensions/extensions'
 require 'rails' if defined?(Rails)
 

--- a/lib/arfi/cli.rb
+++ b/lib/arfi/cli.rb
@@ -3,6 +3,7 @@
 require 'thor'
 require_relative 'commands/init'
 require_relative 'commands/functions'
+require_relative 'commands/triggers'
 
 module Arfi
   # Top-level CLI entrypoint for the `arfi` executable.
@@ -26,6 +27,9 @@ module Arfi
 
     desc 'f_idx [COMMAND]', 'Alias for `arfi functions` (backward compatible).'
     subcommand 'f_idx', Arfi::Commands::Functions
+
+    desc 'triggers [COMMAND]', 'Manage SQL trigger files. Default: list'
+    subcommand 'triggers', Arfi::Commands::Triggers
 
     desc 'version', 'Print the version'
     # Print the gem version to stdout.

--- a/lib/arfi/commands/triggers.rb
+++ b/lib/arfi/commands/triggers.rb
@@ -60,6 +60,10 @@ module Arfi
       option :force, type: :boolean, default: false,
                      desc: 'Overwrite existing trigger file if it already exists.'
       # steep:ignore:end
+      # Method documentation.
+      #
+      # @param [String] trigger_ref Param documentation.
+      # @return [void]
       def create(trigger_ref)
         validate_schema_format!
         validate_adapter_option!
@@ -84,6 +88,10 @@ module Arfi
                        desc: "Specify database adapter. Available adapters: #{ADAPTERS.join(', ')}",
                        banner: 'adapter'
       # steep:ignore:end
+      # Method documentation.
+      #
+      # @param [String] trigger_ref Param documentation.
+      # @return [void]
       def destroy(trigger_ref)
         validate_schema_format!
         validate_adapter_option!
@@ -111,6 +119,9 @@ module Arfi
       option :all, type: :boolean, default: false,
                    desc: 'Show all candidates (including overridden ones), not just the effective set.'
       # steep:ignore:end
+      # Method documentation.
+      #
+      # @return [void]
       def list
         validate_schema_format!
         validate_adapter_option!

--- a/lib/arfi/commands/triggers.rb
+++ b/lib/arfi/commands/triggers.rb
@@ -60,9 +60,12 @@ module Arfi
       option :force, type: :boolean, default: false,
                      desc: 'Overwrite existing trigger file if it already exists.'
       # steep:ignore:end
-      # Method documentation.
+      # Creates a SQL trigger file in db/triggers.
       #
-      # @param [String] trigger_ref Param documentation.
+      # Supports --table, --event, --timing, --for-each, --function, --schema,
+      # --template, --adapter, and --force options.
+      #
+      # @param [String] trigger_ref name or schema.name of the trigger
       # @return [void]
       def create(trigger_ref)
         validate_schema_format!
@@ -88,9 +91,11 @@ module Arfi
                        desc: "Specify database adapter. Available adapters: #{ADAPTERS.join(', ')}",
                        banner: 'adapter'
       # steep:ignore:end
-      # Method documentation.
+      # Deletes a SQL trigger file from db/triggers.
       #
-      # @param [String] trigger_ref Param documentation.
+      # Searches all candidate locations (legacy and new) for the file.
+      #
+      # @param [String] trigger_ref name or schema.name of the trigger
       # @return [void]
       def destroy(trigger_ref)
         validate_schema_format!
@@ -119,7 +124,9 @@ module Arfi
       option :all, type: :boolean, default: false,
                    desc: 'Show all candidates (including overridden ones), not just the effective set.'
       # steep:ignore:end
-      # Method documentation.
+      # Lists trigger SQL files ARFI would load for the chosen adapter.
+      #
+      # Supports --adapter, --format (table|paths|json), and --all flags.
       #
       # @return [void]
       def list

--- a/lib/arfi/commands/triggers.rb
+++ b/lib/arfi/commands/triggers.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'thor'
+require 'rails'
+require 'fileutils'
+require 'json'
+
+require_relative 'triggers_helpers'
+require_relative 'triggers_creation'
+require_relative 'triggers_paths'
+require_relative 'triggers_rendering'
+require_relative 'triggers_candidates'
+
+module Arfi
+  module Commands
+    TRIGGERS_ROOT_DIR = 'db/triggers'
+
+    # Thor CLI for managing SQL trigger files.
+    class Triggers < Thor
+      include TriggersHelpers
+      include TriggersCreation
+      include TriggersPaths
+      include TriggersRendering
+      include TriggersCandidates
+
+      default_task :list
+
+      map %w[ls] => :list
+      map %w[rm delete del] => :destroy
+      map %w[new add] => :create
+
+      # steep:ignore:start
+      desc(
+        'create TRIGGER_NAME [--table=table --event=event --timing=timing ' \
+        '--for-each=row|statement --function=function --schema=schema ' \
+        '--template=template_file --adapter=adapter --force]',
+        "Create (or overwrite with --force) a SQL trigger file.\n  " \
+        "Generic public:      db/triggers/public/<trigger>.sql\n  " \
+        "PostgreSQL public:   db/triggers/postgresql/public/<trigger>.sql\n  " \
+        "PostgreSQL schema:   db/triggers/postgresql/<schema>/<trigger>.sql\n" \
+        "Schema can be passed as 'schema.trigger' or via --schema (PostgreSQL only)."
+      )
+      option :table, type: :string, banner: 'table',
+                     desc: 'Table name the trigger fires on (required).'
+      option :event, type: :string, repeatable: true, banner: 'event',
+                     desc: 'Trigger event: INSERT, UPDATE, DELETE (repeatable for multiple events).'
+      option :timing, type: :string, banner: 'timing',
+                      desc: 'Trigger timing: BEFORE, AFTER, INSTEAD OF.'
+      option :'for-each', type: :string, banner: 'for_each',
+                          desc: 'Trigger scope: ROW or STATEMENT.'
+      option :function, type: :string, banner: 'function',
+                        desc: 'Trigger function name (PostgreSQL only).'
+      option :schema, type: :string, banner: 'schema',
+                      desc: "PostgreSQL schema name (alternative to 'schema.trigger')."
+      option :template, type: :string, banner: 'template_file',
+                        desc: 'Path to the template file. See README.md for details.'
+      option :adapter, type: :string,
+                       desc: "Specify database adapter. Available adapters: #{ADAPTERS.join(', ')}",
+                       banner: 'adapter'
+      option :force, type: :boolean, default: false,
+                     desc: 'Overwrite existing trigger file if it already exists.'
+      # steep:ignore:end
+      def create(trigger_ref)
+        validate_schema_format!
+        validate_adapter_option!
+
+        schema, trigger_name = parse_trigger_ref(trigger_ref)
+        validate_identifiers!(schema, trigger_name)
+
+        ensure_dirs!(adapter: adapter_opt, schema: schema)
+
+        content = build_sql_trigger(schema, trigger_name, original_ref: trigger_ref)
+        write_file(schema, trigger_name, content)
+      end
+
+      # steep:ignore:start
+      desc(
+        'destroy TRIGGER_NAME [--schema=schema --adapter=adapter]',
+        'Delete a SQL trigger file (supports both new and legacy locations).'
+      )
+      option :schema, type: :string, banner: 'schema',
+                      desc: "PostgreSQL schema name (alternative to 'schema.trigger')."
+      option :adapter, type: :string,
+                       desc: "Specify database adapter. Available adapters: #{ADAPTERS.join(', ')}",
+                       banner: 'adapter'
+      # steep:ignore:end
+      def destroy(trigger_ref)
+        validate_schema_format!
+        validate_adapter_option!
+
+        schema, trigger_name = parse_trigger_ref(trigger_ref)
+        validate_identifiers!(schema, trigger_name)
+
+        ensure_dirs!(adapter: adapter_opt, schema: schema)
+
+        remove_trigger_file(schema, trigger_name)
+      end
+
+      # steep:ignore:start
+      desc(
+        'list [--adapter=adapter] [--format=table|paths|json] [--all]',
+        "List SQL trigger files ARFI would load for the chosen adapter.\n" \
+        "Default: inferred adapter from Rails config. Default output: table.\n" \
+        '--all shows shadowed/overridden candidates too.'
+      )
+      option :adapter, type: :string,
+                       desc: "Specify database adapter. Available adapters: #{ADAPTERS.join(', ')}",
+                       banner: 'adapter'
+      option :format, type: :string, default: 'table',
+                      desc: 'Output format: table, paths, json'
+      option :all, type: :boolean, default: false,
+                   desc: 'Show all candidates (including overridden ones), not just the effective set.'
+      # steep:ignore:end
+      def list
+        validate_schema_format!
+        validate_adapter_option!
+
+        adapter = resolve_adapter
+        rows = resolve_triggers_for(adapter: adapter)
+
+        render_list(rows)
+      end
+    end
+  end
+end

--- a/lib/arfi/commands/triggers_candidates.rb
+++ b/lib/arfi/commands/triggers_candidates.rb
@@ -6,6 +6,12 @@ module Arfi
     module TriggersCandidates
       private
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] root Param documentation.
+      # @param [String] adapter Param documentation.
+      # @return [Array<Arfi::Commands::candidate>]
       def collect_all_candidates(root, adapter)
         candidates = generic_candidates(root)
         adapter_root = root.join(adapter)
@@ -16,8 +22,13 @@ module Arfi
         candidates
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Array<Arfi::Commands::candidate>] candidates Param documentation.
+      # @return [Hash<String, Array<Arfi::Commands::candidate>>]
       def group_candidates_by_key(candidates)
-        by_key = Hash.new { |h, k| h[k] = [] }
+        by_key = Hash.new { |h, k| h[k] = [] } # steep:ignore
         candidates.each do |c|
           by_key[c[:key]] << c
         end
@@ -25,20 +36,35 @@ module Arfi
         by_key
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Hash<String, Array<Arfi::Commands::candidate>>] by_key Param documentation.
+      # @return [Array<Hash<Symbol, Object>>]
       def build_resolved_rows(by_key)
         by_key.keys.sort.flat_map do |key|
           resolve_key_group(by_key[key])
         end.compact
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname, String] path Param documentation.
+      # @return [String]
       def rel(path)
         root = Rails.root.to_s
         p = path.to_s
         p.start_with?(root) ? p.sub(root + File::SEPARATOR, '') : p
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] root Param documentation.
+      # @return [Array<Arfi::Commands::candidate>]
       def generic_candidates(root)
-        candidates = []
+        candidates = [] # steep:ignore
         candidates.concat collect_candidates(glob: root.join('*.sql'), schema: DEFAULT_SCHEMA, source: 'generic',
                                              origin: 'legacy', priority: 1)
         candidates.concat collect_candidates(glob: root.join(DEFAULT_SCHEMA, '*.sql'), schema: DEFAULT_SCHEMA,
@@ -46,8 +72,14 @@ module Arfi
         candidates
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] adapter_root Param documentation.
+      # @param [String] adapter Param documentation.
+      # @return [Array<Arfi::Commands::candidate>]
       def adapter_candidates(adapter_root, adapter)
-        candidates = []
+        candidates = [] # steep:ignore
         candidates.concat collect_candidates(glob: adapter_root.join('*.sql'), schema: DEFAULT_SCHEMA,
                                              source: adapter, origin: 'legacy', priority: 8)
         candidates.concat collect_candidates(glob: adapter_root.join(DEFAULT_SCHEMA, '*.sql'),
@@ -55,6 +87,12 @@ module Arfi
         candidates
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] adapter_root Param documentation.
+      # @param [String] adapter Param documentation.
+      # @return [Array<Arfi::Commands::candidate>]
       def collect_postgresql_schema_candidates(adapter_root, adapter)
         Dir.children(adapter_root).sort.each_with_object([]) do |child, acc|
           next if child.start_with?('_')
@@ -68,6 +106,15 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] glob Param documentation.
+      # @param [String] schema Param documentation.
+      # @param [String] source Param documentation.
+      # @param [String] origin Param documentation.
+      # @param [Integer] priority Param documentation.
+      # @return [Array<Arfi::Commands::candidate>]
       def collect_candidates(glob:, schema:, source:, origin:, priority:)
         Dir.glob(glob.to_s).filter_map do |path|
           base = File.basename(path)

--- a/lib/arfi/commands/triggers_candidates.rb
+++ b/lib/arfi/commands/triggers_candidates.rb
@@ -6,11 +6,11 @@ module Arfi
     module TriggersCandidates
       private
 
-      # Method documentation.
+      # Collects all candidate trigger files from generic and adapter-specific directories.
       #
       # @private
-      # @param [Pathname] root Param documentation.
-      # @param [String] adapter Param documentation.
+      # @param [Pathname] root db/triggers
+      # @param [String] adapter database adapter name
       # @return [Array<Arfi::Commands::candidate>]
       def collect_all_candidates(root, adapter)
         candidates = generic_candidates(root)
@@ -22,10 +22,10 @@ module Arfi
         candidates
       end
 
-      # Method documentation.
+      # Groups candidates by their composite key (schema/trigger_name).
       #
       # @private
-      # @param [Array<Arfi::Commands::candidate>] candidates Param documentation.
+      # @param [Array<Arfi::Commands::candidate>] candidates
       # @return [Hash<String, Array<Arfi::Commands::candidate>>]
       def group_candidates_by_key(candidates)
         by_key = Hash.new { |h, k| h[k] = [] } # steep:ignore
@@ -36,10 +36,10 @@ module Arfi
         by_key
       end
 
-      # Method documentation.
+      # Builds the final resolved display rows from grouped candidates.
       #
       # @private
-      # @param [Hash<String, Array<Arfi::Commands::candidate>>] by_key Param documentation.
+      # @param [Hash<String, Array<Arfi::Commands::candidate>>] by_key candidates grouped by key
       # @return [Array<Hash<Symbol, Object>>]
       def build_resolved_rows(by_key)
         by_key.keys.sort.flat_map do |key|
@@ -47,10 +47,10 @@ module Arfi
         end.compact
       end
 
-      # Method documentation.
+      # Converts an absolute path to a Rails-root-relative path for display.
       #
       # @private
-      # @param [Pathname, String] path Param documentation.
+      # @param [Pathname, String] path
       # @return [String]
       def rel(path)
         root = Rails.root.to_s
@@ -58,10 +58,10 @@ module Arfi
         p.start_with?(root) ? p.sub(root + File::SEPARATOR, '') : p
       end
 
-      # Method documentation.
+      # Collects generic (no adapter) candidates from db/triggers/ and db/triggers/public/.
       #
       # @private
-      # @param [Pathname] root Param documentation.
+      # @param [Pathname] root db/triggers
       # @return [Array<Arfi::Commands::candidate>]
       def generic_candidates(root)
         candidates = [] # steep:ignore
@@ -72,11 +72,11 @@ module Arfi
         candidates
       end
 
-      # Method documentation.
+      # Collects adapter-specific candidates from db/triggers/<adapter>/ and db/triggers/<adapter>/public/.
       #
       # @private
-      # @param [Pathname] adapter_root Param documentation.
-      # @param [String] adapter Param documentation.
+      # @param [Pathname] adapter_root db/triggers/<adapter>
+      # @param [String] adapter database adapter name
       # @return [Array<Arfi::Commands::candidate>]
       def adapter_candidates(adapter_root, adapter)
         candidates = [] # steep:ignore
@@ -87,11 +87,11 @@ module Arfi
         candidates
       end
 
-      # Method documentation.
+      # Collects PostgreSQL schema-specific candidates (non-public subdirectories).
       #
       # @private
-      # @param [Pathname] adapter_root Param documentation.
-      # @param [String] adapter Param documentation.
+      # @param [Pathname] adapter_root db/triggers/postgresql
+      # @param [String] adapter "postgresql"
       # @return [Array<Arfi::Commands::candidate>]
       def collect_postgresql_schema_candidates(adapter_root, adapter)
         Dir.children(adapter_root).sort.each_with_object([]) do |child, acc|
@@ -106,14 +106,16 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Collects candidate entries from a glob pattern with metadata.
+      #
+      # Skips files starting with underscore (disabled).
       #
       # @private
-      # @param [Pathname] glob Param documentation.
-      # @param [String] schema Param documentation.
-      # @param [String] source Param documentation.
-      # @param [String] origin Param documentation.
-      # @param [Integer] priority Param documentation.
+      # @param [Pathname] glob glob pattern for matching SQL files
+      # @param [String] schema schema name
+      # @param [String] source "generic" or adapter name
+      # @param [String] origin "legacy" or "explicit"
+      # @param [Integer] priority higher wins when multiple candidates exist for the same key
       # @return [Array<Arfi::Commands::candidate>]
       def collect_candidates(glob:, schema:, source:, origin:, priority:)
         Dir.glob(glob.to_s).filter_map do |path|

--- a/lib/arfi/commands/triggers_candidates.rb
+++ b/lib/arfi/commands/triggers_candidates.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Arfi
+  module Commands
+    # Candidate discovery helpers for {Arfi::Commands::Triggers}.
+    module TriggersCandidates
+      private
+
+      def collect_all_candidates(root, adapter)
+        candidates = generic_candidates(root)
+        adapter_root = root.join(adapter)
+        return candidates unless adapter_root.directory?
+
+        candidates.concat adapter_candidates(adapter_root, adapter)
+        candidates.concat collect_postgresql_schema_candidates(adapter_root, adapter) if adapter == 'postgresql'
+        candidates
+      end
+
+      def group_candidates_by_key(candidates)
+        by_key = Hash.new { |h, k| h[k] = [] }
+        candidates.each do |c|
+          by_key[c[:key]] << c
+        end
+        by_key.each_value { |arr| arr.sort_by! { |c| c[:priority] } }
+        by_key
+      end
+
+      def build_resolved_rows(by_key)
+        by_key.keys.sort.flat_map do |key|
+          resolve_key_group(by_key[key])
+        end.compact
+      end
+
+      def rel(path)
+        root = Rails.root.to_s
+        p = path.to_s
+        p.start_with?(root) ? p.sub(root + File::SEPARATOR, '') : p
+      end
+
+      def generic_candidates(root)
+        candidates = []
+        candidates.concat collect_candidates(glob: root.join('*.sql'), schema: DEFAULT_SCHEMA, source: 'generic',
+                                             origin: 'legacy', priority: 1)
+        candidates.concat collect_candidates(glob: root.join(DEFAULT_SCHEMA, '*.sql'), schema: DEFAULT_SCHEMA,
+                                             source: 'generic', origin: 'explicit', priority: 2)
+        candidates
+      end
+
+      def adapter_candidates(adapter_root, adapter)
+        candidates = []
+        candidates.concat collect_candidates(glob: adapter_root.join('*.sql'), schema: DEFAULT_SCHEMA,
+                                             source: adapter, origin: 'legacy', priority: 8)
+        candidates.concat collect_candidates(glob: adapter_root.join(DEFAULT_SCHEMA, '*.sql'),
+                                             schema: DEFAULT_SCHEMA, source: adapter, origin: 'explicit', priority: 9)
+        candidates
+      end
+
+      def collect_postgresql_schema_candidates(adapter_root, adapter)
+        Dir.children(adapter_root).sort.each_with_object([]) do |child, acc|
+          next if child.start_with?('_')
+          next if child == DEFAULT_SCHEMA
+
+          dir = adapter_root.join(child)
+          next unless dir.directory?
+
+          acc.concat collect_candidates(glob: dir.join('*.sql'), schema: child, source: adapter,
+                                        origin: 'explicit', priority: 10)
+        end
+      end
+
+      def collect_candidates(glob:, schema:, source:, origin:, priority:)
+        Dir.glob(glob.to_s).filter_map do |path|
+          base = File.basename(path)
+          next if base.start_with?('_')
+
+          key = "#{schema}/#{base}"
+          trigger_name = File.basename(path, '.sql')
+          {
+            key: key, schema: schema, trigger: trigger_name,
+            source: source, origin: origin, priority: priority, path: path
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/arfi/commands/triggers_creation.rb
+++ b/lib/arfi/commands/triggers_creation.rb
@@ -6,12 +6,12 @@ module Arfi
     module TriggersCreation
       private
 
-      # Method documentation.
+      # Creates missing subdirectories under db/triggers for the given adapter and schema.
       #
       # @private
-      # @param [String?] adapter Param documentation.
-      # @param [String?] schema Param documentation.
-      # @raise [Arfi::Errors::NoTriggersDir]
+      # @param [String?] adapter e.g. "postgresql", "mysql", or nil for generic
+      # @param [String?] schema e.g. "public", "audit", or nil
+      # @raise [Arfi::Errors::NoTriggersDir] if db/triggers does not exist
       # @return [void]
       def ensure_dirs!(adapter:, schema:)
         root = Rails.root.join(TRIGGERS_ROOT_DIR)
@@ -29,14 +29,17 @@ module Arfi
         FileUtils.mkdir_p(adapter_root.join(sch))
       end
 
-      # Method documentation.
+      # Builds the SQL CREATE TRIGGER statement for the given adapter.
+      #
+      # Delegates to {#build_from_file} when a --template is given, otherwise
+      # dispatches to the adapter-specific skeleton builder.
       #
       # @private
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
-      # @param [String] original_ref Param documentation.
-      # @raise [StandardError]
-      # @return [String]
+      # @param [String?] schema
+      # @param [String] trigger_name
+      # @param [String] original_ref raw CLI argument (for error messages)
+      # @raise [StandardError] if adapter is unknown
+      # @return [String] complete SQL for the trigger
       def build_sql_trigger(schema, trigger_name, original_ref:)
         return build_from_file(schema, trigger_name, original_ref: original_ref) if options[:template]
 
@@ -50,12 +53,14 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Renders trigger SQL from an ERB template file.
+      #
+      # Resolves the schema name, then evaluates the template via {#evaluate_template}.
       #
       # @private
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
-      # @param [String] original_ref Param documentation.
+      # @param [String?] schema
+      # @param [String] trigger_name
+      # @param [String] original_ref raw CLI argument (for error messages)
       # @return [String]
       def build_from_file(schema, trigger_name, original_ref:)
         schema_name = resolve_schema_name(schema)
@@ -63,12 +68,12 @@ module Arfi
         evaluate_template(trigger_name, schema_name, qualified_name, original_ref)
       end
 
-      # Method documentation.
+      # Writes a trigger SQL file to disk unless it exists (no --force).
       #
       # @private
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
-      # @param [String] content Param documentation.
+      # @param [String?] schema
+      # @param [String] trigger_name
+      # @param [String] content the SQL content to write
       # @return [void]
       def write_file(schema, trigger_name, content)
         path = canonical_path(schema, trigger_name)
@@ -80,11 +85,11 @@ module Arfi
         puts "Created: #{rel(path)}"
       end
 
-      # Method documentation.
+      # Removes a trigger SQL file from the appropriate adapter/generic directory.
       #
       # @private
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
+      # @param [String?] schema
+      # @param [String] trigger_name
       # @return [void]
       def remove_trigger_file(schema, trigger_name)
         candidates = trigger_paths(schema, trigger_name)
@@ -97,14 +102,18 @@ module Arfi
         puts "Deleted: #{rel(path)}"
       end
 
-      # Method documentation.
+      # Evaluates an ERB template file as an inline Ruby string with binding.
+      #
+      # Reads --template path, wraps it in a heredoc, compiles with RubyVM, and evals.
+      # The template has access to: trigger_name, schema_name, qualified_name, original_ref.
       #
       # @private
-      # @param [String] trigger_name Param documentation.
-      # @param [String?] schema_name Param documentation.
-      # @param [String] qualified_name Param documentation.
-      # @param [String] original_ref Param documentation.
-      # @return [Object]
+      # @param [String] trigger_name
+      # @param [String?] schema_name resolved schema or nil
+      # @param [String] qualified_name schema.trigger_name or just trigger_name
+      # @param [String] original_ref raw CLI argument (for error messages)
+      # @raise [StandardError] if template file is missing or eval fails
+      # @return [String] rendered SQL
       def evaluate_template(trigger_name, schema_name, qualified_name, original_ref)
         tpl = File.read(options[:template])
         RubyVM::InstructionSequence.compile(<<~RUBY).eval # steep:ignore
@@ -117,12 +126,14 @@ module Arfi
         RUBY
       end
 
-      # Method documentation.
+      # Generates a PostgreSQL skeleton CREATE TRIGGER with EXECUTE FUNCTION.
+      #
+      # Uses CLI options: --table, --event (repeatable), --timing, --for-each, --function.
       #
       # @private
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
-      # @return [String]
+      # @param [String?] schema
+      # @param [String] trigger_name
+      # @return [String] the generated SQL
       def build_postgresql_trigger_skeleton(schema, trigger_name)
         sch = schema || DEFAULT_SCHEMA
         fn_name = options[:function] || "#{trigger_name}_fn"
@@ -130,13 +141,13 @@ module Arfi
         "-- #{note}\n#{pg_trigger_sql(trigger_name, sch, fn_name)}"
       end
 
-      # Method documentation.
+      # Formats the CREATE TRIGGER SQL for PostgreSQL with schema-qualified names.
       #
       # @private
-      # @param [Object] trigger_name Param documentation.
-      # @param [Object] sch Param documentation.
-      # @param [Object] fn_name Param documentation.
-      # @return [String]
+      # @param [String] trigger_name
+      # @param [String] sch schema name
+      # @param [String] fn_name function name
+      # @return [String] the formatted SQL
       def pg_trigger_sql(trigger_name, sch, fn_name)
         <<~SQL
           CREATE TRIGGER #{trigger_name}
@@ -146,43 +157,46 @@ module Arfi
         SQL
       end
 
-      # Method documentation.
+      # Returns the table name from --table option or a placeholder.
       #
       # @private
-      # @return [Object]
+      # @return [String]
       def pg_table
         options[:table] || 'table_name'
       end
 
-      # Method documentation.
+      # Returns the trigger timing from --timing option or defaults to BEFORE.
       #
       # @private
-      # @return [Object]
+      # @return [String]
       def pg_timing
         options[:timing] || 'BEFORE'
       end
 
-      # Method documentation.
+      # Returns FOR EACH scope from --for-each option or defaults to ROW.
       #
       # @private
-      # @return [Object]
+      # @return [String]
       def pg_for_each
         options[:'for-each'] || 'ROW'
       end
 
-      # Method documentation.
+      # Builds the event clause (INSERT, UPDATE, DELETE) from --event options.
       #
       # @private
-      # @return [Object]
+      # @return [String] e.g. "INSERT OR UPDATE OR DELETE"
       def pg_trigger_events
         Array(options[:event]).then { _1.empty? ? %w[INSERT] : _1 }.map(&:upcase).join(' OR ')
       end
 
-      # Method documentation.
+      # Generates a MySQL skeleton CREATE TRIGGER with BEGIN ... END body.
+      #
+      # Uses CLI options: --table, --event (first only -- MySQL supports one event),
+      # --timing, --for-each.
       #
       # @private
-      # @param [String] trigger_name Param documentation.
-      # @return [String]
+      # @param [String] trigger_name
+      # @return [String] the generated SQL
       def build_mysql_trigger_skeleton(trigger_name)
         table = options[:table] || 'table_name'
         timing = options[:timing] || 'BEFORE'
@@ -191,14 +205,14 @@ module Arfi
         "#{note}\n#{mysql_trigger_sql(trigger_name, timing, event, table)}"
       end
 
-      # Method documentation.
+      # Formats the CREATE TRIGGER SQL for MySQL with the given parameters.
       #
       # @private
-      # @param [Object] trigger_name Param documentation.
-      # @param [Object] timing Param documentation.
-      # @param [Object] event Param documentation.
-      # @param [Object] table Param documentation.
-      # @return [String]
+      # @param [String] trigger_name
+      # @param [String] timing BEFORE or AFTER
+      # @param [String] event INSERT, UPDATE, or DELETE
+      # @param [String] table
+      # @return [String] the formatted SQL
       def mysql_trigger_sql(trigger_name, timing, event, table)
         <<~SQL
           CREATE TRIGGER #{trigger_name}

--- a/lib/arfi/commands/triggers_creation.rb
+++ b/lib/arfi/commands/triggers_creation.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Arfi
+  module Commands
+    # Trigger file creation helpers for {Arfi::Commands::Triggers}.
+    module TriggersCreation
+      private
+
+      def ensure_dirs!(adapter:, schema:)
+        root = Rails.root.join(TRIGGERS_ROOT_DIR)
+        raise Arfi::Errors::NoTriggersDir unless root.directory?
+
+        FileUtils.mkdir_p(root.join(DEFAULT_SCHEMA))
+        return if adapter.nil?
+
+        adapter_root = root.join(adapter)
+        FileUtils.mkdir_p(adapter_root)
+        FileUtils.mkdir_p(adapter_root.join(DEFAULT_SCHEMA))
+        return unless adapter == 'postgresql'
+
+        sch = schema || DEFAULT_SCHEMA
+        FileUtils.mkdir_p(adapter_root.join(sch))
+      end
+
+      def build_sql_trigger(schema, trigger_name, original_ref:)
+        return build_from_file(schema, trigger_name, original_ref: original_ref) if options[:template]
+
+        opt = adapter_opt
+        if opt.nil? || opt == 'postgresql'
+          build_postgresql_trigger_skeleton(schema, trigger_name)
+        elsif %w[mysql trilogy].include?(opt)
+          build_mysql_trigger_skeleton(trigger_name)
+        else
+          raise "Unknown adapter: #{opt}. Supported adapters: #{ADAPTERS.join(', ')}"
+        end
+      end
+
+      def build_from_file(schema, trigger_name, original_ref:)
+        schema_name = resolve_schema_name(schema)
+        qualified_name = schema_name ? "#{schema_name}.#{trigger_name}" : trigger_name
+        evaluate_template(trigger_name, schema_name, qualified_name, original_ref)
+      end
+
+      def write_file(schema, trigger_name, content)
+        path = canonical_path(schema, trigger_name)
+        if File.exist?(path) && !options[:force]
+          puts "Already exists: #{rel(path)} (use --force to overwrite)"
+          return
+        end
+        File.write(path, content.to_s)
+        puts "Created: #{rel(path)}"
+      end
+
+      def remove_trigger_file(schema, trigger_name)
+        candidates = trigger_paths(schema, trigger_name)
+        path = candidates.find { |p| File.exist?(p) }
+        unless path
+          puts "Not found. Looked in:\n  - #{candidates.map { rel(_1) }.join("\n  - ")}"
+          return
+        end
+        FileUtils.rm(path)
+        puts "Deleted: #{rel(path)}"
+      end
+
+      def evaluate_template(trigger_name, schema_name, qualified_name, original_ref)
+        tpl = File.read(options[:template])
+        RubyVM::InstructionSequence.compile(<<~RUBY).eval
+          index_name     = #{trigger_name.inspect}
+          trigger_name   = #{trigger_name.inspect}
+          schema_name    = #{schema_name.inspect}
+          qualified_name = #{qualified_name.inspect}
+          original_ref   = #{original_ref.inspect}
+          #{tpl}
+        RUBY
+      end
+
+      def build_postgresql_trigger_skeleton(schema, trigger_name)
+        sch = schema || DEFAULT_SCHEMA
+        fn_name = options[:function] || "#{trigger_name}_fn"
+        note = "You will need a trigger function: arfi functions create #{fn_name} --schema #{sch}"
+        "-- #{note}\n#{pg_trigger_sql(trigger_name, sch, fn_name)}"
+      end
+
+      def pg_trigger_sql(trigger_name, sch, fn_name)
+        <<~SQL
+          CREATE TRIGGER #{trigger_name}
+              #{pg_timing} #{pg_trigger_events} ON #{sch}.#{pg_table}
+              FOR EACH #{pg_for_each}
+              EXECUTE FUNCTION #{sch}.#{fn_name}();
+        SQL
+      end
+
+      def pg_table
+        options[:table] || 'table_name'
+      end
+
+      def pg_timing
+        options[:timing] || 'BEFORE'
+      end
+
+      def pg_for_each
+        options[:'for-each'] || 'ROW'
+      end
+
+      def pg_trigger_events
+        Array(options[:event]).then { _1.empty? ? %w[INSERT] : _1 }.map(&:upcase).join(' OR ')
+      end
+
+      def build_mysql_trigger_skeleton(trigger_name)
+        table = options[:table] || 'table_name'
+        timing = options[:timing] || 'BEFORE'
+        event = Array(options[:event]).first || 'INSERT'
+        note = '-- You may need DROP TRIGGER IF EXISTS and multi-statement connection'
+        "#{note}\n#{mysql_trigger_sql(trigger_name, timing, event, table)}"
+      end
+
+      def mysql_trigger_sql(trigger_name, timing, event, table)
+        <<~SQL
+          CREATE TRIGGER #{trigger_name}
+              #{timing} #{event.upcase} ON #{table}
+              FOR EACH ROW
+          BEGIN
+              -- Trigger body here
+          END;
+        SQL
+      end
+    end
+  end
+end

--- a/lib/arfi/commands/triggers_creation.rb
+++ b/lib/arfi/commands/triggers_creation.rb
@@ -6,6 +6,13 @@ module Arfi
     module TriggersCreation
       private
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] adapter Param documentation.
+      # @param [String?] schema Param documentation.
+      # @raise [Arfi::Errors::NoTriggersDir]
+      # @return [void]
       def ensure_dirs!(adapter:, schema:)
         root = Rails.root.join(TRIGGERS_ROOT_DIR)
         raise Arfi::Errors::NoTriggersDir unless root.directory?
@@ -22,6 +29,14 @@ module Arfi
         FileUtils.mkdir_p(adapter_root.join(sch))
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @param [String] original_ref Param documentation.
+      # @raise [StandardError]
+      # @return [String]
       def build_sql_trigger(schema, trigger_name, original_ref:)
         return build_from_file(schema, trigger_name, original_ref: original_ref) if options[:template]
 
@@ -35,12 +50,26 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @param [String] original_ref Param documentation.
+      # @return [String]
       def build_from_file(schema, trigger_name, original_ref:)
         schema_name = resolve_schema_name(schema)
         qualified_name = schema_name ? "#{schema_name}.#{trigger_name}" : trigger_name
         evaluate_template(trigger_name, schema_name, qualified_name, original_ref)
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @param [String] content Param documentation.
+      # @return [void]
       def write_file(schema, trigger_name, content)
         path = canonical_path(schema, trigger_name)
         if File.exist?(path) && !options[:force]
@@ -51,6 +80,12 @@ module Arfi
         puts "Created: #{rel(path)}"
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @return [void]
       def remove_trigger_file(schema, trigger_name)
         candidates = trigger_paths(schema, trigger_name)
         path = candidates.find { |p| File.exist?(p) }
@@ -62,9 +97,17 @@ module Arfi
         puts "Deleted: #{rel(path)}"
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String] trigger_name Param documentation.
+      # @param [String?] schema_name Param documentation.
+      # @param [String] qualified_name Param documentation.
+      # @param [String] original_ref Param documentation.
+      # @return [Object]
       def evaluate_template(trigger_name, schema_name, qualified_name, original_ref)
         tpl = File.read(options[:template])
-        RubyVM::InstructionSequence.compile(<<~RUBY).eval
+        RubyVM::InstructionSequence.compile(<<~RUBY).eval # steep:ignore
           index_name     = #{trigger_name.inspect}
           trigger_name   = #{trigger_name.inspect}
           schema_name    = #{schema_name.inspect}
@@ -74,6 +117,12 @@ module Arfi
         RUBY
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @return [String]
       def build_postgresql_trigger_skeleton(schema, trigger_name)
         sch = schema || DEFAULT_SCHEMA
         fn_name = options[:function] || "#{trigger_name}_fn"
@@ -81,6 +130,13 @@ module Arfi
         "-- #{note}\n#{pg_trigger_sql(trigger_name, sch, fn_name)}"
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Object] trigger_name Param documentation.
+      # @param [Object] sch Param documentation.
+      # @param [Object] fn_name Param documentation.
+      # @return [String]
       def pg_trigger_sql(trigger_name, sch, fn_name)
         <<~SQL
           CREATE TRIGGER #{trigger_name}
@@ -90,22 +146,43 @@ module Arfi
         SQL
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @return [Object]
       def pg_table
         options[:table] || 'table_name'
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @return [Object]
       def pg_timing
         options[:timing] || 'BEFORE'
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @return [Object]
       def pg_for_each
         options[:'for-each'] || 'ROW'
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @return [Object]
       def pg_trigger_events
         Array(options[:event]).then { _1.empty? ? %w[INSERT] : _1 }.map(&:upcase).join(' OR ')
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String] trigger_name Param documentation.
+      # @return [String]
       def build_mysql_trigger_skeleton(trigger_name)
         table = options[:table] || 'table_name'
         timing = options[:timing] || 'BEFORE'
@@ -114,6 +191,14 @@ module Arfi
         "#{note}\n#{mysql_trigger_sql(trigger_name, timing, event, table)}"
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Object] trigger_name Param documentation.
+      # @param [Object] timing Param documentation.
+      # @param [Object] event Param documentation.
+      # @param [Object] table Param documentation.
+      # @return [String]
       def mysql_trigger_sql(trigger_name, timing, event, table)
         <<~SQL
           CREATE TRIGGER #{trigger_name}

--- a/lib/arfi/commands/triggers_helpers.rb
+++ b/lib/arfi/commands/triggers_helpers.rb
@@ -6,7 +6,7 @@ module Arfi
     module TriggersHelpers
       private
 
-      # Method documentation.
+      # Raises unless schema format is :ruby (ARFI requires schema.rb).
       #
       # @private
       # @raise [Arfi::Errors::InvalidSchemaFormat]
@@ -21,7 +21,7 @@ module Arfi
         raise Arfi::Errors::InvalidSchemaFormat unless fmt == :ruby
       end
 
-      # Method documentation.
+      # Raises unless --adapter value (if given) is in the supported list.
       #
       # @private
       # @raise [Arfi::Errors::AdapterNotSupported]
@@ -32,10 +32,12 @@ module Arfi
         raise Arfi::Errors::AdapterNotSupported unless ADAPTERS.map(&:to_s).include?(opt)
       end
 
-      # Method documentation.
+      # Parses a trigger reference string into [schema, trigger_name].
+      #
+      # Supports "schema.name" format and/or --schema option.
       #
       # @private
-      # @param [String] ref Param documentation.
+      # @param [String] ref e.g. "public.my_trigger" or "my_trigger"
       # @return [[ ::String?, ::String ]]
       def parse_trigger_ref(ref)
         validate_trigger_ref!(ref)
@@ -49,12 +51,14 @@ module Arfi
         [schema, parsed_fn || '']
       end
 
-      # Method documentation.
+      # Validates that schema and trigger names match the allowed identifier pattern.
+      #
+      # Also rejects schema-qualified triggers for non-PostgreSQL adapters.
       #
       # @private
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
-      # @raise [ArgumentError]
+      # @param [String?] schema
+      # @param [String] trigger_name
+      # @raise [ArgumentError] if names are invalid or schema not allowed for adapter
       # @return [void]
       def validate_identifiers!(schema, trigger_name)
         raise ArgumentError, "Invalid trigger name: #{trigger_name.inspect}" unless IDENT.match?(trigger_name)
@@ -65,11 +69,11 @@ module Arfi
         raise ArgumentError, 'Schema-qualified triggers are only supported for PostgreSQL.'
       end
 
-      # Method documentation.
+      # Validates the raw trigger reference string (non-empty, no path separators).
       #
       # @private
-      # @param [String] ref Param documentation.
-      # @raise [ArgumentError]
+      # @param [String] ref
+      # @raise [ArgumentError] if ref is empty or contains path separators
       # @return [void]
       def validate_trigger_ref!(ref)
         raise ArgumentError, "Invalid trigger name: #{ref.inspect}" unless ref.is_a?(String)
@@ -79,10 +83,10 @@ module Arfi
         raise ArgumentError, "Invalid trigger name: #{ref.inspect}" if bad
       end
 
-      # Method documentation.
+      # Raises if schema is provided both via "schema.name" and --schema option.
       #
       # @private
-      # @param [String?] parsed_schema Param documentation.
+      # @param [String?] parsed_schema schema extracted from the ref string
       # @raise [ArgumentError]
       # @return [void]
       def check_schema_conflict!(parsed_schema)
@@ -91,20 +95,20 @@ module Arfi
         raise ArgumentError, "Schema specified twice (both 'schema.trigger' and --schema). Pick one."
       end
 
-      # Method documentation.
+      # Resolves the schema name: returns schema or DEFAULT_SCHEMA for PostgreSQL/generic, nil for MySQL.
       #
       # @private
-      # @param [String?] schema Param documentation.
+      # @param [String?] schema
       # @return [String?]
       def resolve_schema_name(schema)
         adapter = adapter_opt
         adapter.nil? || adapter == 'postgresql' ? (schema || DEFAULT_SCHEMA) : nil
       end
 
-      # Method documentation.
+      # Resolves the database adapter: --adapter option, inferred from Rails config, or raises.
       #
       # @private
-      # @raise [ArgumentError]
+      # @raise [ArgumentError] if adapter cannot be determined
       # @return [String]
       def resolve_adapter
         adapter_opt || infer_adapter_from_config || raise(
@@ -113,12 +117,12 @@ module Arfi
         )
       end
 
-      # Method documentation.
+      # Collects, groups, and resolves all candidate SQL files for the given adapter.
       #
       # @private
-      # @param [String] adapter Param documentation.
-      # @raise [Arfi::Errors::NoTriggersDir]
-      # @return [Array<Hash<Symbol, Object>>]
+      # @param [String] adapter database adapter name
+      # @raise [Arfi::Errors::NoTriggersDir] if db/triggers does not exist
+      # @return [Array<Hash<Symbol, Object>>] resolved display rows
       def resolve_triggers_for(adapter:)
         root = Rails.root.join(TRIGGERS_ROOT_DIR)
         raise Arfi::Errors::NoTriggersDir unless root.directory?
@@ -128,7 +132,7 @@ module Arfi
         build_resolved_rows(by_key)
       end
 
-      # Method documentation.
+      # Returns the --adapter CLI option value as a string, or nil.
       #
       # @private
       # @return [String?]
@@ -136,7 +140,7 @@ module Arfi
         options[:adapter]&.to_s
       end
 
-      # Method documentation.
+      # Returns the --schema CLI option value as a string, or nil.
       #
       # @private
       # @return [String?]
@@ -144,12 +148,11 @@ module Arfi
         options[:schema]&.to_s
       end
 
-      # Method documentation.
+      # Infers the database adapter name from the primary Rails database config.
       #
       # @private
-      # @raise [StandardError]
+      # @raise [StandardError] if config lookup fails
       # @return [String?]
-      # @return [nil] if StandardError
       def infer_adapter_from_config
         cfg = primary_db_config
         h = cfg&.configuration_hash
@@ -159,10 +162,10 @@ module Arfi
         nil
       end
 
-      # Method documentation.
+      # Returns the primary (or first) database config for the current Rails env.
       #
       # @private
-      # @return [Object]
+      # @return [Object] ActiveRecord::DatabaseConfigurations::HashConfig or similar
       def primary_db_config
         cfgs =
           if ActiveRecord::Base.respond_to?(:configurations) && ActiveRecord::Base.configurations

--- a/lib/arfi/commands/triggers_helpers.rb
+++ b/lib/arfi/commands/triggers_helpers.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Arfi
+  module Commands
+    # Shared helper methods for {Arfi::Commands::Triggers}.
+    module TriggersHelpers
+      private
+
+      def validate_schema_format!
+        fmt =
+          if defined?(Rails) && Rails.application
+            Rails.application.config.active_record.schema_format
+          elsif defined?(ActiveRecord::Base) && ActiveRecord::Base.respond_to?(:schema_format)
+            ActiveRecord::Base.schema_format
+          end
+        raise Arfi::Errors::InvalidSchemaFormat unless fmt == :ruby
+      end
+
+      def validate_adapter_option!
+        opt = adapter_opt
+        return if opt.nil?
+        raise Arfi::Errors::AdapterNotSupported unless ADAPTERS.map(&:to_s).include?(opt)
+      end
+
+      def parse_trigger_ref(ref)
+        validate_trigger_ref!(ref)
+        parsed_schema, parsed_fn = ref.split('.', 2)
+        if parsed_fn.nil?
+          parsed_fn = parsed_schema
+          parsed_schema = nil
+        end
+        check_schema_conflict!(parsed_schema)
+        schema = schema_opt || parsed_schema
+        [schema, parsed_fn || '']
+      end
+
+      def validate_identifiers!(schema, trigger_name)
+        raise ArgumentError, "Invalid trigger name: #{trigger_name.inspect}" unless IDENT.match?(trigger_name)
+        return if schema.nil?
+        raise ArgumentError, "Invalid schema name: #{schema.inspect}" unless IDENT.match?(schema)
+        return unless adapter_opt && adapter_opt != 'postgresql'
+
+        raise ArgumentError, 'Schema-qualified triggers are only supported for PostgreSQL.'
+      end
+
+      def validate_trigger_ref!(ref)
+        raise ArgumentError, "Invalid trigger name: #{ref.inspect}" unless ref.is_a?(String)
+
+        sep = [File::SEPARATOR, File::ALT_SEPARATOR].compact
+        bad = ref.empty? || ref.include?('..') || sep.any? { |s| ref.include?(s) }
+        raise ArgumentError, "Invalid trigger name: #{ref.inspect}" if bad
+      end
+
+      def check_schema_conflict!(parsed_schema)
+        return unless schema_opt && parsed_schema
+
+        raise ArgumentError, "Schema specified twice (both 'schema.trigger' and --schema). Pick one."
+      end
+
+      def resolve_schema_name(schema)
+        adapter = adapter_opt
+        adapter.nil? || adapter == 'postgresql' ? (schema || DEFAULT_SCHEMA) : nil
+      end
+
+      def resolve_adapter
+        adapter_opt || infer_adapter_from_config || raise(
+          ArgumentError,
+          'Could not infer adapter. Pass --adapter=[postgresql|mysql|trilogy].'
+        )
+      end
+
+      def resolve_triggers_for(adapter:)
+        root = Rails.root.join(TRIGGERS_ROOT_DIR)
+        raise Arfi::Errors::NoTriggersDir unless root.directory?
+
+        candidates = collect_all_candidates(root, adapter)
+        by_key = group_candidates_by_key(candidates)
+        build_resolved_rows(by_key)
+      end
+
+      def adapter_opt
+        options[:adapter]&.to_s
+      end
+
+      def schema_opt
+        options[:schema]&.to_s
+      end
+
+      def infer_adapter_from_config
+        cfg = primary_db_config
+        h = cfg&.configuration_hash
+        adapter = h && (h[:adapter] || h['adapter'])
+        adapter&.to_s
+      rescue StandardError
+        nil
+      end
+
+      def primary_db_config
+        cfgs =
+          if ActiveRecord::Base.respond_to?(:configurations) && ActiveRecord::Base.configurations
+            ActiveRecord::Base.configurations.configurations.select { _1.env_name == Rails.env }
+          else
+            []
+          end
+        cfgs.find { _1.name == 'primary' } || cfgs.first
+      end
+    end
+  end
+end

--- a/lib/arfi/commands/triggers_helpers.rb
+++ b/lib/arfi/commands/triggers_helpers.rb
@@ -6,6 +6,11 @@ module Arfi
     module TriggersHelpers
       private
 
+      # Method documentation.
+      #
+      # @private
+      # @raise [Arfi::Errors::InvalidSchemaFormat]
+      # @return [void]
       def validate_schema_format!
         fmt =
           if defined?(Rails) && Rails.application
@@ -16,12 +21,22 @@ module Arfi
         raise Arfi::Errors::InvalidSchemaFormat unless fmt == :ruby
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @raise [Arfi::Errors::AdapterNotSupported]
+      # @return [void]
       def validate_adapter_option!
         opt = adapter_opt
         return if opt.nil?
         raise Arfi::Errors::AdapterNotSupported unless ADAPTERS.map(&:to_s).include?(opt)
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String] ref Param documentation.
+      # @return [[ ::String?, ::String ]]
       def parse_trigger_ref(ref)
         validate_trigger_ref!(ref)
         parsed_schema, parsed_fn = ref.split('.', 2)
@@ -34,6 +49,13 @@ module Arfi
         [schema, parsed_fn || '']
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @raise [ArgumentError]
+      # @return [void]
       def validate_identifiers!(schema, trigger_name)
         raise ArgumentError, "Invalid trigger name: #{trigger_name.inspect}" unless IDENT.match?(trigger_name)
         return if schema.nil?
@@ -43,6 +65,12 @@ module Arfi
         raise ArgumentError, 'Schema-qualified triggers are only supported for PostgreSQL.'
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String] ref Param documentation.
+      # @raise [ArgumentError]
+      # @return [void]
       def validate_trigger_ref!(ref)
         raise ArgumentError, "Invalid trigger name: #{ref.inspect}" unless ref.is_a?(String)
 
@@ -51,17 +79,33 @@ module Arfi
         raise ArgumentError, "Invalid trigger name: #{ref.inspect}" if bad
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] parsed_schema Param documentation.
+      # @raise [ArgumentError]
+      # @return [void]
       def check_schema_conflict!(parsed_schema)
         return unless schema_opt && parsed_schema
 
         raise ArgumentError, "Schema specified twice (both 'schema.trigger' and --schema). Pick one."
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] schema Param documentation.
+      # @return [String?]
       def resolve_schema_name(schema)
         adapter = adapter_opt
         adapter.nil? || adapter == 'postgresql' ? (schema || DEFAULT_SCHEMA) : nil
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @raise [ArgumentError]
+      # @return [String]
       def resolve_adapter
         adapter_opt || infer_adapter_from_config || raise(
           ArgumentError,
@@ -69,6 +113,12 @@ module Arfi
         )
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String] adapter Param documentation.
+      # @raise [Arfi::Errors::NoTriggersDir]
+      # @return [Array<Hash<Symbol, Object>>]
       def resolve_triggers_for(adapter:)
         root = Rails.root.join(TRIGGERS_ROOT_DIR)
         raise Arfi::Errors::NoTriggersDir unless root.directory?
@@ -78,14 +128,28 @@ module Arfi
         build_resolved_rows(by_key)
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @return [String?]
       def adapter_opt
         options[:adapter]&.to_s
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @return [String?]
       def schema_opt
         options[:schema]&.to_s
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @raise [StandardError]
+      # @return [String?]
+      # @return [nil] if StandardError
       def infer_adapter_from_config
         cfg = primary_db_config
         h = cfg&.configuration_hash
@@ -95,12 +159,16 @@ module Arfi
         nil
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @return [Object]
       def primary_db_config
         cfgs =
           if ActiveRecord::Base.respond_to?(:configurations) && ActiveRecord::Base.configurations
             ActiveRecord::Base.configurations.configurations.select { _1.env_name == Rails.env }
           else
-            []
+            [] # steep:ignore
           end
         cfgs.find { _1.name == 'primary' } || cfgs.first
       end

--- a/lib/arfi/commands/triggers_paths.rb
+++ b/lib/arfi/commands/triggers_paths.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Arfi
+  module Commands
+    # Path resolution helpers for {Arfi::Commands::Triggers}.
+    module TriggersPaths
+      private
+
+      def canonical_path(schema, trigger_name)
+        root = Rails.root.join(TRIGGERS_ROOT_DIR)
+        if adapter_opt.nil?
+          generic_canonical_path(root, schema, trigger_name)
+        else
+          adapter_canonical_path(root, schema, trigger_name)
+        end
+      end
+
+      def trigger_paths(schema, trigger_name)
+        root = Rails.root.join(TRIGGERS_ROOT_DIR)
+        out = case adapter_opt
+              when nil then generic_trigger_paths(root, trigger_name)
+              when 'postgresql' then postgresql_trigger_paths(root, schema, trigger_name)
+              when 'mysql', 'trilogy' then mysql_trigger_paths(root, trigger_name)
+              else raise Arfi::Errors::AdapterNotSupported
+              end
+        out.uniq
+      end
+
+      def generic_canonical_path(root, schema, trigger_name)
+        sch = schema || DEFAULT_SCHEMA
+        unless sch == DEFAULT_SCHEMA
+          raise ArgumentError,
+                "Generic triggers can only target schema '#{DEFAULT_SCHEMA}'"
+        end
+        root.join(DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s
+      end
+
+      def adapter_canonical_path(root, schema, trigger_name)
+        case adapter_opt
+        when 'postgresql'
+          root.join('postgresql', schema || DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s
+        when 'mysql', 'trilogy'
+          raise ArgumentError, 'Schema-qualified triggers are only supported for PostgreSQL.' if schema
+
+          root.join('mysql', DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s
+        else
+          raise Arfi::Errors::AdapterNotSupported
+        end
+      end
+
+      def generic_trigger_paths(root, trigger_name)
+        [
+          root.join(DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s,
+          root.join("#{trigger_name}.sql").to_s
+        ]
+      end
+
+      def postgresql_trigger_paths(root, schema, trigger_name)
+        sch = schema || DEFAULT_SCHEMA
+        out = [
+          root.join('postgresql', sch, "#{trigger_name}.sql").to_s,
+          root.join('postgresql', DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s,
+          root.join(DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s,
+          root.join("#{trigger_name}.sql").to_s
+        ]
+        out.insert(2, root.join('postgresql', "#{trigger_name}.sql").to_s) if sch == DEFAULT_SCHEMA
+        out
+      end
+
+      def mysql_trigger_paths(root, trigger_name)
+        [
+          root.join('mysql', DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s,
+          root.join('mysql', "#{trigger_name}.sql").to_s,
+          root.join(DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s,
+          root.join("#{trigger_name}.sql").to_s
+        ]
+      end
+    end
+  end
+end

--- a/lib/arfi/commands/triggers_paths.rb
+++ b/lib/arfi/commands/triggers_paths.rb
@@ -6,6 +6,12 @@ module Arfi
     module TriggersPaths
       private
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @return [String]
       def canonical_path(schema, trigger_name)
         root = Rails.root.join(TRIGGERS_ROOT_DIR)
         if adapter_opt.nil?
@@ -15,6 +21,13 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @raise [Arfi::Errors::AdapterNotSupported]
+      # @return [Array<String>]
       def trigger_paths(schema, trigger_name)
         root = Rails.root.join(TRIGGERS_ROOT_DIR)
         out = case adapter_opt
@@ -26,6 +39,14 @@ module Arfi
         out.uniq
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] root Param documentation.
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @raise [ArgumentError]
+      # @return [String]
       def generic_canonical_path(root, schema, trigger_name)
         sch = schema || DEFAULT_SCHEMA
         unless sch == DEFAULT_SCHEMA
@@ -35,6 +56,15 @@ module Arfi
         root.join(DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] root Param documentation.
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @raise [ArgumentError]
+      # @raise [Arfi::Errors::AdapterNotSupported]
+      # @return [String]
       def adapter_canonical_path(root, schema, trigger_name)
         case adapter_opt
         when 'postgresql'
@@ -48,6 +78,12 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] root Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @return [Array<String>]
       def generic_trigger_paths(root, trigger_name)
         [
           root.join(DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s,
@@ -55,6 +91,13 @@ module Arfi
         ]
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] root Param documentation.
+      # @param [String?] schema Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @return [Array<String>]
       def postgresql_trigger_paths(root, schema, trigger_name)
         sch = schema || DEFAULT_SCHEMA
         out = [
@@ -67,6 +110,12 @@ module Arfi
         out
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] root Param documentation.
+      # @param [String] trigger_name Param documentation.
+      # @return [Array<String>]
       def mysql_trigger_paths(root, trigger_name)
         [
           root.join('mysql', DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s,

--- a/lib/arfi/commands/triggers_paths.rb
+++ b/lib/arfi/commands/triggers_paths.rb
@@ -6,12 +6,14 @@ module Arfi
     module TriggersPaths
       private
 
-      # Method documentation.
+      # Returns the canonical write path for a trigger SQL file.
+      #
+      # Dispatches to generic or adapter-specific path builder based on adapter_opt.
       #
       # @private
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
-      # @return [String]
+      # @param [String?] schema
+      # @param [String] trigger_name
+      # @return [String] full file path
       def canonical_path(schema, trigger_name)
         root = Rails.root.join(TRIGGERS_ROOT_DIR)
         if adapter_opt.nil?
@@ -21,11 +23,13 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Returns an ordered list of paths to search for an existing trigger SQL file.
+      #
+      # Used by destroy to find files in legacy or new locations.
       #
       # @private
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
+      # @param [String?] schema
+      # @param [String] trigger_name
       # @raise [Arfi::Errors::AdapterNotSupported]
       # @return [Array<String>]
       def trigger_paths(schema, trigger_name)
@@ -39,13 +43,15 @@ module Arfi
         out.uniq
       end
 
-      # Method documentation.
+      # Returns the canonical write path for generic (no adapter) triggers.
+      #
+      # Only supports the DEFAULT_SCHEMA (public).
       #
       # @private
-      # @param [Pathname] root Param documentation.
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
-      # @raise [ArgumentError]
+      # @param [Pathname] root db/triggers
+      # @param [String?] schema
+      # @param [String] trigger_name
+      # @raise [ArgumentError] if schema is not DEFAULT_SCHEMA
       # @return [String]
       def generic_canonical_path(root, schema, trigger_name)
         sch = schema || DEFAULT_SCHEMA
@@ -56,13 +62,15 @@ module Arfi
         root.join(DEFAULT_SCHEMA, "#{trigger_name}.sql").to_s
       end
 
-      # Method documentation.
+      # Returns the canonical write path for adapter-specific triggers.
+      #
+      # PostgreSQL supports schema-qualified paths; MySQL/Trilogy only use public.
       #
       # @private
-      # @param [Pathname] root Param documentation.
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
-      # @raise [ArgumentError]
+      # @param [Pathname] root db/triggers
+      # @param [String?] schema
+      # @param [String] trigger_name
+      # @raise [ArgumentError] if schema is given for MySQL/Trilogy
       # @raise [Arfi::Errors::AdapterNotSupported]
       # @return [String]
       def adapter_canonical_path(root, schema, trigger_name)
@@ -78,11 +86,11 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Search paths for generic (no adapter) triggers, legacy then explicit.
       #
       # @private
-      # @param [Pathname] root Param documentation.
-      # @param [String] trigger_name Param documentation.
+      # @param [Pathname] root db/triggers
+      # @param [String] trigger_name
       # @return [Array<String>]
       def generic_trigger_paths(root, trigger_name)
         [
@@ -91,12 +99,12 @@ module Arfi
         ]
       end
 
-      # Method documentation.
+      # Search paths for PostgreSQL triggers, from most to least specific.
       #
       # @private
-      # @param [Pathname] root Param documentation.
-      # @param [String?] schema Param documentation.
-      # @param [String] trigger_name Param documentation.
+      # @param [Pathname] root db/triggers
+      # @param [String?] schema
+      # @param [String] trigger_name
       # @return [Array<String>]
       def postgresql_trigger_paths(root, schema, trigger_name)
         sch = schema || DEFAULT_SCHEMA
@@ -110,11 +118,11 @@ module Arfi
         out
       end
 
-      # Method documentation.
+      # Search paths for MySQL/Trilogy triggers, from most to least specific.
       #
       # @private
-      # @param [Pathname] root Param documentation.
-      # @param [String] trigger_name Param documentation.
+      # @param [Pathname] root db/triggers
+      # @param [String] trigger_name
       # @return [Array<String>]
       def mysql_trigger_paths(root, trigger_name)
         [

--- a/lib/arfi/commands/triggers_rendering.rb
+++ b/lib/arfi/commands/triggers_rendering.rb
@@ -6,6 +6,11 @@ module Arfi
     module TriggersRendering
       private
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Array<Hash<Symbol, Object>>] rows Param documentation.
+      # @return [void]
       def render_list(rows)
         case options[:format].to_s
         when 'paths'
@@ -13,10 +18,15 @@ module Arfi
         when 'json'
           puts JSON.pretty_generate(rows.map { |r| r.merge(path: rel(r[:path])) })
         else
-          print_table(rows)
+          print_table(rows) # steep:ignore
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Array<Arfi::Commands::resolved_row>] rows Param documentation.
+      # @return [void]
       def print_table(rows)
         cols = table_columns
         table = stringify_rows(rows)
@@ -26,6 +36,10 @@ module Arfi
         render_table_rows(table, cols, widths)
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @return [Array<String>]
       def table_columns
         if options[:all]
           %w[chosen schema trigger source origin priority path shadowed_by]
@@ -34,6 +48,11 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Array<Arfi::Commands::resolved_row>] rows Param documentation.
+      # @return [Array<Arfi::Commands::resolved_row>]
       def stringify_rows(rows)
         rows.map do |r|
           r = r.dup
@@ -44,20 +63,38 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Array<String>] cols Param documentation.
+      # @param [Array<Arfi::Commands::resolved_row>] table Param documentation.
+      # @return [Hash<String, Integer>]
       def calculate_widths(cols, table)
-        widths = {}
+        widths = {} # steep:ignore
         cols.each do |c|
           widths[c] = ([c.length] + table.map { |r| r[c.to_sym].to_s.length }).max
         end
         widths
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Array<Arfi::Commands::resolved_row>] table Param documentation.
+      # @param [Array<String>] cols Param documentation.
+      # @param [Hash<String, Integer>] widths Param documentation.
+      # @return [void]
       def render_table_rows(table, cols, widths)
         table.each do |r|
           puts cols.map { |c| r[c.to_sym].to_s.ljust(widths[c]) }.join('  ')
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Array<Arfi::Commands::candidate>] arr Param documentation.
+      # @return [Array<Hash<Symbol, Object>>]
       def resolve_key_group(arr)
         chosen = arr.max_by { |c| c[:priority] }
         return [] unless chosen
@@ -69,9 +106,15 @@ module Arfi
         end
       end
 
-      def all_mode_rows(arr, chosen)
+      # Method documentation.
+      #
+      # @private
+      # @param [Array<Arfi::Commands::candidate>] arr Param documentation.
+      # @param [Arfi::Commands::candidate] chosen Param documentation.
+      # @return [Array<Hash<Symbol, Object>>]
+      def all_mode_rows(arr, chosen) # steep:ignore
         chosen_path = chosen[:path]
-        arr.sort_by { |c| [-c[:priority], c[:schema], c[:trigger]] }.map do |c|
+        arr.sort_by { |c| [-c[:priority], c[:schema], c[:trigger]] }.map do |c| # steep:ignore
           c.merge(
             chosen: (c == chosen),
             shadowed_by: (c == chosen ? nil : rel(chosen_path))
@@ -79,7 +122,13 @@ module Arfi
         end
       end
 
-      def default_mode_row(chosen, arr)
+      # Method documentation.
+      #
+      # @private
+      # @param [Arfi::Commands::candidate] chosen Param documentation.
+      # @param [Array<Arfi::Commands::candidate>] arr Param documentation.
+      # @return [Array<Hash<Symbol, Object>>]
+      def default_mode_row(chosen, arr) # steep:ignore
         shadowed = (arr - [chosen])
         [chosen.merge(chosen: true, shadowed: shadowed.map { rel(_1[:path]) })]
       end

--- a/lib/arfi/commands/triggers_rendering.rb
+++ b/lib/arfi/commands/triggers_rendering.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Arfi
+  module Commands
+    # Table rendering helpers for {Arfi::Commands::Triggers}.
+    module TriggersRendering
+      private
+
+      def render_list(rows)
+        case options[:format].to_s
+        when 'paths'
+          rows.each { puts rel(_1[:path]) }
+        when 'json'
+          puts JSON.pretty_generate(rows.map { |r| r.merge(path: rel(r[:path])) })
+        else
+          print_table(rows)
+        end
+      end
+
+      def print_table(rows)
+        cols = table_columns
+        table = stringify_rows(rows)
+        widths = calculate_widths(cols, table)
+        puts cols.map { |c| c.ljust(widths[c]) }.join('  ')
+        puts cols.map { |c| '-' * widths[c] }.join('  ')
+        render_table_rows(table, cols, widths)
+      end
+
+      def table_columns
+        if options[:all]
+          %w[chosen schema trigger source origin priority path shadowed_by]
+        else
+          %w[schema trigger source origin priority path shadowed]
+        end
+      end
+
+      def stringify_rows(rows)
+        rows.map do |r|
+          r = r.dup
+          r[:path] = rel(r[:path])
+          r[:chosen] = r[:chosen] ? 'yes' : 'no' if r.key?(:chosen)
+          r[:shadowed] = (r[:shadowed] || []).join(', ') if r.key?(:shadowed)
+          r
+        end
+      end
+
+      def calculate_widths(cols, table)
+        widths = {}
+        cols.each do |c|
+          widths[c] = ([c.length] + table.map { |r| r[c.to_sym].to_s.length }).max
+        end
+        widths
+      end
+
+      def render_table_rows(table, cols, widths)
+        table.each do |r|
+          puts cols.map { |c| r[c.to_sym].to_s.ljust(widths[c]) }.join('  ')
+        end
+      end
+
+      def resolve_key_group(arr)
+        chosen = arr.max_by { |c| c[:priority] }
+        return [] unless chosen
+
+        if options[:all]
+          all_mode_rows(arr, chosen)
+        else
+          default_mode_row(chosen, arr)
+        end
+      end
+
+      def all_mode_rows(arr, chosen)
+        chosen_path = chosen[:path]
+        arr.sort_by { |c| [-c[:priority], c[:schema], c[:trigger]] }.map do |c|
+          c.merge(
+            chosen: (c == chosen),
+            shadowed_by: (c == chosen ? nil : rel(chosen_path))
+          )
+        end
+      end
+
+      def default_mode_row(chosen, arr)
+        shadowed = (arr - [chosen])
+        [chosen.merge(chosen: true, shadowed: shadowed.map { rel(_1[:path]) })]
+      end
+    end
+  end
+end

--- a/lib/arfi/commands/triggers_rendering.rb
+++ b/lib/arfi/commands/triggers_rendering.rb
@@ -6,10 +6,10 @@ module Arfi
     module TriggersRendering
       private
 
-      # Method documentation.
+      # Renders trigger list in the selected output format (paths, json, or table).
       #
       # @private
-      # @param [Array<Hash<Symbol, Object>>] rows Param documentation.
+      # @param [Array<Hash<Symbol, Object>>] rows resolved trigger rows
       # @return [void]
       def render_list(rows)
         case options[:format].to_s
@@ -22,10 +22,10 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Prints a formatted table of resolved trigger rows to stdout.
       #
       # @private
-      # @param [Array<Arfi::Commands::resolved_row>] rows Param documentation.
+      # @param [Array<Arfi::Commands::resolved_row>] rows
       # @return [void]
       def print_table(rows)
         cols = table_columns
@@ -36,7 +36,9 @@ module Arfi
         render_table_rows(table, cols, widths)
       end
 
-      # Method documentation.
+      # Returns the column headers for the table view.
+      #
+      # Includes extra columns when --all is set.
       #
       # @private
       # @return [Array<String>]
@@ -48,10 +50,10 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Converts row values to strings for table display (path, chosen, shadowed).
       #
       # @private
-      # @param [Array<Arfi::Commands::resolved_row>] rows Param documentation.
+      # @param [Array<Arfi::Commands::resolved_row>] rows
       # @return [Array<Arfi::Commands::resolved_row>]
       def stringify_rows(rows)
         rows.map do |r|
@@ -63,11 +65,11 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Calculates column widths based on header and row values.
       #
       # @private
-      # @param [Array<String>] cols Param documentation.
-      # @param [Array<Arfi::Commands::resolved_row>] table Param documentation.
+      # @param [Array<String>] cols column names
+      # @param [Array<Arfi::Commands::resolved_row>] table stringified rows
       # @return [Hash<String, Integer>]
       def calculate_widths(cols, table)
         widths = {} # steep:ignore
@@ -77,12 +79,12 @@ module Arfi
         widths
       end
 
-      # Method documentation.
+      # Prints each table row with proper column padding.
       #
       # @private
-      # @param [Array<Arfi::Commands::resolved_row>] table Param documentation.
-      # @param [Array<String>] cols Param documentation.
-      # @param [Hash<String, Integer>] widths Param documentation.
+      # @param [Array<Arfi::Commands::resolved_row>] table
+      # @param [Array<String>] cols
+      # @param [Hash<String, Integer>] widths
       # @return [void]
       def render_table_rows(table, cols, widths)
         table.each do |r|
@@ -90,10 +92,12 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Resolves a group of candidates (same key) into display rows.
+      #
+      # Chooses the highest-priority candidate; shows shadowed candidates with --all.
       #
       # @private
-      # @param [Array<Arfi::Commands::candidate>] arr Param documentation.
+      # @param [Array<Arfi::Commands::candidate>] arr candidates for one key
       # @return [Array<Hash<Symbol, Object>>]
       def resolve_key_group(arr)
         chosen = arr.max_by { |c| c[:priority] }
@@ -106,11 +110,11 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Builds display rows for --all mode, including shadowed candidates.
       #
       # @private
-      # @param [Array<Arfi::Commands::candidate>] arr Param documentation.
-      # @param [Arfi::Commands::candidate] chosen Param documentation.
+      # @param [Array<Arfi::Commands::candidate>] arr
+      # @param [Arfi::Commands::candidate] chosen highest-priority candidate
       # @return [Array<Hash<Symbol, Object>>]
       def all_mode_rows(arr, chosen) # steep:ignore
         chosen_path = chosen[:path]
@@ -122,11 +126,11 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Builds a single display row for default mode with shadowed paths list.
       #
       # @private
-      # @param [Arfi::Commands::candidate] chosen Param documentation.
-      # @param [Array<Arfi::Commands::candidate>] arr Param documentation.
+      # @param [Arfi::Commands::candidate] chosen
+      # @param [Array<Arfi::Commands::candidate>] arr all candidates for the key
       # @return [Array<Hash<Symbol, Object>>]
       def default_mode_row(chosen, arr) # steep:ignore
         shadowed = (arr - [chosen])

--- a/lib/arfi/errors.rb
+++ b/lib/arfi/errors.rb
@@ -38,5 +38,18 @@ module Arfi
         super
       end
     end
+
+    # Raised when there is no `db/triggers` directory in the Rails project.
+    class NoTriggersDir < StandardError
+      # Initialize a new NoTriggersDir error with an optional custom message.
+      #
+      # @param [String] message Error message
+      # @return [void]
+      def initialize(message =
+                       'There is no such directory: db/triggers. Did you run `bundle exec arfi triggers create`?')
+        @message = message
+        super
+      end
+    end
   end
 end

--- a/lib/arfi/extensions/active_record/base.rb
+++ b/lib/arfi/extensions/active_record/base.rb
@@ -42,5 +42,53 @@ module ActiveRecord
         LIMIT 1;
       SQL
     end
+
+    # Check if a SQL trigger exists in the database, dispatching to the correct adapter method.
+    #
+    # @param [String] table Table name
+    # @param [String] trigger_name Trigger name to check
+    # @raise [ActiveRecord::AdapterNotFound] If adapter is not supported
+    # @return [Boolean] Whether the trigger exists
+    def self.trigger_exists?(table, trigger_name)
+      case connection.class.name
+      when 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
+        pg_trigger_exists?(table, trigger_name)
+      when 'ActiveRecord::ConnectionAdapters::Mysql2Adapter', 'ActiveRecord::ConnectionAdapters::TrilogyAdapter'
+        mysql_trigger_exists?(table, trigger_name)
+      else
+        raise ActiveRecord::AdapterNotFound, "adapter #{connection.class.name} is not supported"
+      end
+    end
+
+    # Check if a trigger exists in PostgreSQL via pg_trigger catalog table.
+    #
+    # @param [String] table Table name
+    # @param [String] trigger_name Trigger name to check
+    # @return [Boolean] Whether the trigger exists
+    def self.pg_trigger_exists?(table, trigger_name)
+      sql = <<~SQL.squish
+        SELECT 1 FROM pg_trigger t
+        JOIN pg_class c ON c.oid = t.tgrelid
+        WHERE t.tgname = #{connection.quote(trigger_name)}
+          AND c.relname = #{connection.quote(table)}
+        LIMIT 1
+      SQL
+      !connection.select_value(sql).nil?
+    end
+
+    # Check if a trigger exists in MySQL/MariaDB via information_schema.TRIGGERS.
+    #
+    # @param [String] table Table name
+    # @param [String] trigger_name Trigger name to check
+    # @return [Boolean] Whether the trigger exists
+    def self.mysql_trigger_exists?(table, trigger_name)
+      !connection.select_value(<<~SQL).nil?
+        SELECT 1 FROM information_schema.TRIGGERS
+        WHERE TRIGGER_SCHEMA = #{connection.quote(connection.current_database)}
+          AND EVENT_OBJECT_TABLE = #{connection.quote(table)}
+          AND TRIGGER_NAME = #{connection.quote(trigger_name)}
+        LIMIT 1;
+      SQL
+    end
   end
 end

--- a/lib/arfi/sql_trigger_loader.rb
+++ b/lib/arfi/sql_trigger_loader.rb
@@ -6,12 +6,15 @@ module Arfi
   # Mirror of {Arfi::SqlFunctionLoader} for triggers with `db/triggers` paths.
   class SqlTriggerLoader
     class << self
-      # Method documentation.
+      # Loads all trigger SQL files into the database for the current adapter.
       #
-      # @param [String?] task_name Param documentation.
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter?] connection Param documentation.
-      # @param [Boolean] clear_active_connections Param documentation.
-      # @param [Boolean] verbose Param documentation.
+      # Handles multi-DB setups by iterating all configurations when no specific
+      # connection or task_name is given.
+      #
+      # @param [String?] task_name Rake task name for logging
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter?] connection optional specific connection
+      # @param [Boolean] clear_active_connections whether to clear connections after loading
+      # @param [Boolean] verbose whether to log each loaded file
       # @return [void]
       def load!(task_name: nil, connection: nil, clear_active_connections: true, verbose: true)
         task_short = task_name ? task_name[/([^:]+$)/] : nil
@@ -30,7 +33,7 @@ module Arfi
 
       private
 
-      # Method documentation.
+      # Returns true if more than one database configuration exists for the current env.
       #
       # @private
       # @return [Boolean]
@@ -38,10 +41,10 @@ module Arfi
         ActiveRecord::Base.configurations.configurations.count { _1.env_name == Rails.env } > 1
       end
 
-      # Method documentation.
+      # Raises unless the connection adapter is one of the supported types.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
       # @raise [Arfi::Errors::AdapterNotSupported]
       # @return [void]
       def raise_unless_supported_adapter(conn) # rubocop:disable SortedMethodsByCall/Waterfall
@@ -54,11 +57,13 @@ module Arfi
         raise Arfi::Errors::AdapterNotSupported unless allowed.include?(conn.class.name)
       end
 
-      # Method documentation.
+      # Iterates all database configs for the current env and loads triggers into each.
+      #
+      # Restores the original connection after loading.
       #
       # @private
-      # @param [Boolean] verbose Param documentation.
-      # @param [String?] task_name Param documentation.
+      # @param [Boolean] verbose
+      # @param [String?] task_name
       # @return [void]
       def populate_multiple_db(verbose:, task_name: nil)
         original = current_db_config
@@ -70,7 +75,7 @@ module Arfi
         ActiveRecord::Base.establish_connection(original) if original
       end
 
-      # Method documentation.
+      # Returns the default ActiveRecord connection, handling the lease_connection API change.
       #
       # @private
       # @return [ActiveRecord::ConnectionAdapters::AbstractAdapter]
@@ -82,24 +87,23 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Returns the current database config object, or nil on error.
       #
       # @private
       # @raise [StandardError]
-      # @return [Object]
-      # @return [nil] if StandardError
+      # @return [Object] ActiveRecord::DatabaseConfigurations::HashConfig or similar
       def current_db_config
         ActiveRecord::Base.connection_db_config
       rescue StandardError
         nil
       end
 
-      # Method documentation.
+      # Loads all SQL trigger files for a single connection.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
-      # @param [Boolean] verbose Param documentation.
-      # @param [String?] task_name Param documentation.
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [Boolean] verbose
+      # @param [String?] task_name
       # @return [void]
       def populate_db(conn, verbose:, task_name:)
         files = sql_files(conn)
@@ -111,10 +115,12 @@ module Arfi
         files.each { |file| load_sql_file(conn, file, verbose, task_name) }
       end
 
-      # Method documentation.
+      # Clears all active connections unless suppressed by caller.
+      #
+      # Handles both old and new ActiveRecord connection handler APIs.
       #
       # @private
-      # @param [Boolean] clear Param documentation.
+      # @param [Boolean] clear whether to actually clear
       # @return [void]
       def clear_active_connections_if_needed(clear)
         return unless clear && defined?(ActiveRecord::Base)
@@ -127,14 +133,16 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Executes a single SQL file against the given connection.
+      #
+      # Re-raises with the file path appended to the error message on failure.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
-      # @param [Pathname, String] file Param documentation.
-      # @param [Boolean] verbose Param documentation.
-      # @param [String?] task_name Param documentation.
-      # @raise [StandardError]
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [Pathname, String] file path to the SQL file
+      # @param [Boolean] verbose
+      # @param [String?] task_name
+      # @raise [StandardError] on SQL execution failure
       # @return [void]
       def load_sql_file(conn, file, verbose, task_name)
         sql = File.read(file.to_s).strip
@@ -150,12 +158,12 @@ module Arfi
         log_sql_load(conn, file, task_name)
       end
 
-      # Method documentation.
+      # Logs a successful trigger load to Rails logger or stdout.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
-      # @param [Pathname, String] file Param documentation.
-      # @param [String?] task_name Param documentation.
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [Pathname, String] file path to the loaded SQL file
+      # @param [String?] task_name
       # @return [void]
       def log_sql_load(conn, file, task_name)
         label = "[ARFI] Loaded trigger: #{File.basename(file)} into #{safe_db_env(conn)} #{safe_db_name(conn)}"
@@ -163,37 +171,35 @@ module Arfi
         log(conn, label)
       end
 
-      # Method documentation.
+      # Safely returns the database environment name, or empty string on error.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
       # @raise [StandardError]
       # @return [String]
-      # @return [String] if StandardError
       def safe_db_env(conn)
         conn.pool&.db_config&.env_name.to_s
       rescue StandardError
         ''
       end
 
-      # Method documentation.
+      # Safely returns the database config name, or empty string on error.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
       # @raise [StandardError]
       # @return [String]
-      # @return [String] if StandardError
       def safe_db_name(conn)
         conn.pool&.db_config&.name.to_s
       rescue StandardError
         ''
       end
 
-      # Method documentation.
+      # Logs a message via Rails logger or stdout.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] _conn Param documentation.
-      # @param [String] msg Param documentation.
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] _conn (unused, kept for interface consistency)
+      # @param [String] msg message to log
       # @return [void]
       def log(_conn, msg)
         if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
@@ -203,11 +209,13 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Discovers and returns SQL trigger files for the given connection's adapter.
+      #
+      # Merges generic and adapter-specific files, deduplicating by priority.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
-      # @return [Array<String>]
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @return [Array<String>] sorted list of file paths
       def sql_files(conn)
         root = Rails.root.join('db', 'triggers')
         return [] unless root.directory?
@@ -223,11 +231,11 @@ module Arfi
         finalize_items(generic + collect_adapter_sql_files(conn, adapter_root))
       end
 
-      # Method documentation.
+      # Collects adapter-specific SQL files, dispatching by connection class.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
-      # @param [Pathname] adapter_root Param documentation.
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [Pathname] adapter_root db/triggers/<adapter>
       # @raise [Arfi::Errors::AdapterNotSupported]
       # @return [Array<Arfi::sql_file_item>]
       def collect_adapter_sql_files(conn, adapter_root)
@@ -241,10 +249,10 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Collects PostgreSQL SQL files, including schema-specific subdirectories.
       #
       # @private
-      # @param [Pathname] adapter_root Param documentation.
+      # @param [Pathname] adapter_root db/triggers/postgresql
       # @return [Array<Arfi::sql_file_item>]
       def collect_postgresql_sql_files(adapter_root)
         items = collect_adapter_public_sql_files(adapter_root)
@@ -262,10 +270,10 @@ module Arfi
         items
       end
 
-      # Method documentation.
+      # Collects adapter SQL files from the root and public/ subdirectory.
       #
       # @private
-      # @param [Pathname] adapter_root Param documentation.
+      # @param [Pathname] adapter_root db/triggers/<adapter>
       # @return [Array<Arfi::sql_file_item>]
       def collect_adapter_public_sql_files(adapter_root)
         items = [] # steep:ignore
@@ -274,12 +282,14 @@ module Arfi
         items
       end
 
-      # Method documentation.
+      # Collects SQL file items from a glob pattern.
+      #
+      # Skips files starting with underscore (disabled).
       #
       # @private
-      # @param [Pathname, String] glob Param documentation.
-      # @param [String] schema Param documentation.
-      # @param [Integer] priority Param documentation.
+      # @param [Pathname, String] glob glob pattern
+      # @param [String] schema schema name
+      # @param [Integer] priority priority for deduplication
       # @return [Array<Arfi::sql_file_item>]
       def collect_sql(glob:, schema:, priority:)
         Dir.glob(glob.to_s).filter_map do |path|
@@ -290,11 +300,13 @@ module Arfi
         end
       end
 
-      # Method documentation.
+      # Deduplicates items by key (schema/base), keeping the highest-priority each.
+      #
+      # Returns sorted file paths.
       #
       # @private
-      # @param [Array<Arfi::sql_file_item>] items Param documentation.
-      # @return [Array<String>]
+      # @param [Array<Arfi::sql_file_item>] items all discovered items
+      # @return [Array<String>] sorted, deduplicated file paths
       def finalize_items(items)
         chosen = {} # steep:ignore
 
@@ -309,11 +321,11 @@ module Arfi
               .map { |item| item[:path] }
       end
 
-      # Method documentation.
+      # Returns the adapter-specific subdirectory under db/triggers for the given connection.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
-      # @param [Pathname] root Param documentation.
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [Pathname] root db/triggers
       # @raise [Arfi::Errors::AdapterNotSupported]
       # @return [Pathname]
       def adapter_root_for(conn, root)

--- a/lib/arfi/sql_trigger_loader.rb
+++ b/lib/arfi/sql_trigger_loader.rb
@@ -6,6 +6,13 @@ module Arfi
   # Mirror of {Arfi::SqlFunctionLoader} for triggers with `db/triggers` paths.
   class SqlTriggerLoader
     class << self
+      # Method documentation.
+      #
+      # @param [String?] task_name Param documentation.
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter?] connection Param documentation.
+      # @param [Boolean] clear_active_connections Param documentation.
+      # @param [Boolean] verbose Param documentation.
+      # @return [void]
       def load!(task_name: nil, connection: nil, clear_active_connections: true, verbose: true)
         task_short = task_name ? task_name[/([^:]+$)/] : nil
         conn = connection || default_connection
@@ -23,10 +30,20 @@ module Arfi
 
       private
 
+      # Method documentation.
+      #
+      # @private
+      # @return [Boolean]
       def multi_db?
         ActiveRecord::Base.configurations.configurations.count { _1.env_name == Rails.env } > 1
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @raise [Arfi::Errors::AdapterNotSupported]
+      # @return [void]
       def raise_unless_supported_adapter(conn) # rubocop:disable SortedMethodsByCall/Waterfall
         allowed = %w[
           ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
@@ -37,6 +54,12 @@ module Arfi
         raise Arfi::Errors::AdapterNotSupported unless allowed.include?(conn.class.name)
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Boolean] verbose Param documentation.
+      # @param [String?] task_name Param documentation.
+      # @return [void]
       def populate_multiple_db(verbose:, task_name: nil)
         original = current_db_config
         ActiveRecord::Base.configurations.configurations.select { _1.env_name == Rails.env }.each do |config|
@@ -47,6 +70,10 @@ module Arfi
         ActiveRecord::Base.establish_connection(original) if original
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @return [ActiveRecord::ConnectionAdapters::AbstractAdapter]
       def default_connection
         if Rails::VERSION::MAJOR < 7 || (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR < 2)
           ActiveRecord::Base.connection
@@ -55,12 +82,25 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @raise [StandardError]
+      # @return [Object]
+      # @return [nil] if StandardError
       def current_db_config
         ActiveRecord::Base.connection_db_config
       rescue StandardError
         nil
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @param [Boolean] verbose Param documentation.
+      # @param [String?] task_name Param documentation.
+      # @return [void]
       def populate_db(conn, verbose:, task_name:)
         files = sql_files(conn)
         if files.empty?
@@ -71,6 +111,11 @@ module Arfi
         files.each { |file| load_sql_file(conn, file, verbose, task_name) }
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Boolean] clear Param documentation.
+      # @return [void]
       def clear_active_connections_if_needed(clear)
         return unless clear && defined?(ActiveRecord::Base)
 
@@ -82,6 +127,15 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @param [Pathname, String] file Param documentation.
+      # @param [Boolean] verbose Param documentation.
+      # @param [String?] task_name Param documentation.
+      # @raise [StandardError]
+      # @return [void]
       def load_sql_file(conn, file, verbose, task_name)
         sql = File.read(file.to_s).strip
         return if sql.empty?
@@ -96,24 +150,51 @@ module Arfi
         log_sql_load(conn, file, task_name)
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @param [Pathname, String] file Param documentation.
+      # @param [String?] task_name Param documentation.
+      # @return [void]
       def log_sql_load(conn, file, task_name)
         label = "[ARFI] Loaded trigger: #{File.basename(file)} into #{safe_db_env(conn)} #{safe_db_name(conn)}"
         label += " (#{task_name})" if task_name
         log(conn, label)
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @raise [StandardError]
+      # @return [String]
+      # @return [String] if StandardError
       def safe_db_env(conn)
         conn.pool&.db_config&.env_name.to_s
       rescue StandardError
         ''
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @raise [StandardError]
+      # @return [String]
+      # @return [String] if StandardError
       def safe_db_name(conn)
         conn.pool&.db_config&.name.to_s
       rescue StandardError
         ''
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] _conn Param documentation.
+      # @param [String] msg Param documentation.
+      # @return [void]
       def log(_conn, msg)
         if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
           Rails.logger.info(msg)
@@ -122,6 +203,11 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @return [Array<String>]
       def sql_files(conn)
         root = Rails.root.join('db', 'triggers')
         return [] unless root.directory?
@@ -137,6 +223,13 @@ module Arfi
         finalize_items(generic + collect_adapter_sql_files(conn, adapter_root))
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @param [Pathname] adapter_root Param documentation.
+      # @raise [Arfi::Errors::AdapterNotSupported]
+      # @return [Array<Arfi::sql_file_item>]
       def collect_adapter_sql_files(conn, adapter_root)
         case conn.class.name
         when 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
@@ -148,6 +241,11 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] adapter_root Param documentation.
+      # @return [Array<Arfi::sql_file_item>]
       def collect_postgresql_sql_files(adapter_root)
         items = collect_adapter_public_sql_files(adapter_root)
 
@@ -164,13 +262,25 @@ module Arfi
         items
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname] adapter_root Param documentation.
+      # @return [Array<Arfi::sql_file_item>]
       def collect_adapter_public_sql_files(adapter_root)
-        items = []
+        items = [] # steep:ignore
         items.concat collect_sql(glob: adapter_root.join('*.sql'), schema: 'public', priority: 8)
         items.concat collect_sql(glob: adapter_root.join('public', '*.sql'), schema: 'public', priority: 9)
         items
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Pathname, String] glob Param documentation.
+      # @param [String] schema Param documentation.
+      # @param [Integer] priority Param documentation.
+      # @return [Array<Arfi::sql_file_item>]
       def collect_sql(glob:, schema:, priority:)
         Dir.glob(glob.to_s).filter_map do |path|
           base = File.basename(path)
@@ -180,8 +290,13 @@ module Arfi
         end
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [Array<Arfi::sql_file_item>] items Param documentation.
+      # @return [Array<String>]
       def finalize_items(items)
-        chosen = {}
+        chosen = {} # steep:ignore
 
         items.each do |item|
           key = "#{item[:schema]}/#{item[:base]}"
@@ -194,6 +309,13 @@ module Arfi
               .map { |item| item[:path] }
       end
 
+      # Method documentation.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn Param documentation.
+      # @param [Pathname] root Param documentation.
+      # @raise [Arfi::Errors::AdapterNotSupported]
+      # @return [Pathname]
       def adapter_root_for(conn, root)
         case conn.class.name
         when 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'

--- a/lib/arfi/sql_trigger_loader.rb
+++ b/lib/arfi/sql_trigger_loader.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+module Arfi
+  # Loads user-defined SQL triggers into the database by executing SQL files located under `db/triggers`.
+  #
+  # Mirror of {Arfi::SqlFunctionLoader} for triggers with `db/triggers` paths.
+  class SqlTriggerLoader
+    class << self
+      def load!(task_name: nil, connection: nil, clear_active_connections: true, verbose: true)
+        task_short = task_name ? task_name[/([^:]+$)/] : nil
+        conn = connection || default_connection
+
+        raise_unless_supported_adapter(conn)
+
+        if connection.nil? && multi_db? && task_name.nil?
+          populate_multiple_db(verbose: verbose, task_name: task_short)
+        else
+          populate_db(conn, verbose: verbose, task_name: task_short)
+        end
+      ensure
+        clear_active_connections_if_needed(clear_active_connections)
+      end
+
+      private
+
+      def multi_db?
+        ActiveRecord::Base.configurations.configurations.count { _1.env_name == Rails.env } > 1
+      end
+
+      def raise_unless_supported_adapter(conn) # rubocop:disable SortedMethodsByCall/Waterfall
+        allowed = %w[
+          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+          ActiveRecord::ConnectionAdapters::Mysql2Adapter
+          ActiveRecord::ConnectionAdapters::TrilogyAdapter
+        ].freeze
+
+        raise Arfi::Errors::AdapterNotSupported unless allowed.include?(conn.class.name)
+      end
+
+      def populate_multiple_db(verbose:, task_name: nil)
+        original = current_db_config
+        ActiveRecord::Base.configurations.configurations.select { _1.env_name == Rails.env }.each do |config|
+          ActiveRecord::Base.establish_connection(config)
+          populate_db(default_connection, verbose: verbose, task_name: task_name)
+        end
+      ensure
+        ActiveRecord::Base.establish_connection(original) if original
+      end
+
+      def default_connection
+        if Rails::VERSION::MAJOR < 7 || (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR < 2)
+          ActiveRecord::Base.connection
+        else
+          ActiveRecord::Base.lease_connection
+        end
+      end
+
+      def current_db_config
+        ActiveRecord::Base.connection_db_config
+      rescue StandardError
+        nil
+      end
+
+      def populate_db(conn, verbose:, task_name:)
+        files = sql_files(conn)
+        if files.empty?
+          log(conn, "No SQL files found for adapter #{conn.class}. Skipping trigger loading")
+          return
+        end
+
+        files.each { |file| load_sql_file(conn, file, verbose, task_name) }
+      end
+
+      def clear_active_connections_if_needed(clear)
+        return unless clear && defined?(ActiveRecord::Base)
+
+        if ActiveRecord::Base.respond_to?(:connection_handler) &&
+           ActiveRecord::Base.connection_handler.respond_to?(:clear_active_connections!)
+          ActiveRecord::Base.connection_handler.clear_active_connections!
+        elsif ActiveRecord::Base.respond_to?(:clear_active_connections!)
+          ActiveRecord::Base.clear_active_connections!
+        end
+      end
+
+      def load_sql_file(conn, file, verbose, task_name)
+        sql = File.read(file.to_s).strip
+        return if sql.empty?
+
+        begin
+          conn.execute(sql)
+        rescue StandardError => e
+          raise e.class, "#{e.message}\n[ARFI] while loading #{file}", e.backtrace
+        end
+        return unless verbose
+
+        log_sql_load(conn, file, task_name)
+      end
+
+      def log_sql_load(conn, file, task_name)
+        label = "[ARFI] Loaded trigger: #{File.basename(file)} into #{safe_db_env(conn)} #{safe_db_name(conn)}"
+        label += " (#{task_name})" if task_name
+        log(conn, label)
+      end
+
+      def safe_db_env(conn)
+        conn.pool&.db_config&.env_name.to_s
+      rescue StandardError
+        ''
+      end
+
+      def safe_db_name(conn)
+        conn.pool&.db_config&.name.to_s
+      rescue StandardError
+        ''
+      end
+
+      def log(_conn, msg)
+        if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
+          Rails.logger.info(msg)
+        else
+          $stdout.puts(msg)
+        end
+      end
+
+      def sql_files(conn)
+        root = Rails.root.join('db', 'triggers')
+        return [] unless root.directory?
+
+        generic = [
+          collect_sql(glob: root.join('*.sql'), schema: 'public', priority: 1),
+          collect_sql(glob: root.join('public', '*.sql'), schema: 'public', priority: 2)
+        ].flatten
+
+        adapter_root = adapter_root_for(conn, root)
+        return finalize_items(generic) unless adapter_root&.directory?
+
+        finalize_items(generic + collect_adapter_sql_files(conn, adapter_root))
+      end
+
+      def collect_adapter_sql_files(conn, adapter_root)
+        case conn.class.name
+        when 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
+          collect_postgresql_sql_files(adapter_root)
+        when 'ActiveRecord::ConnectionAdapters::Mysql2Adapter', 'ActiveRecord::ConnectionAdapters::TrilogyAdapter'
+          collect_adapter_public_sql_files(adapter_root)
+        else
+          raise Arfi::Errors::AdapterNotSupported
+        end
+      end
+
+      def collect_postgresql_sql_files(adapter_root)
+        items = collect_adapter_public_sql_files(adapter_root)
+
+        Dir.children(adapter_root).sort.each do |child|
+          next if child.start_with?('_')
+          next if child == 'public'
+
+          dir = adapter_root.join(child)
+          next unless dir.directory?
+
+          items.concat collect_sql(glob: dir.join('*.sql'), schema: child, priority: 10)
+        end
+
+        items
+      end
+
+      def collect_adapter_public_sql_files(adapter_root)
+        items = []
+        items.concat collect_sql(glob: adapter_root.join('*.sql'), schema: 'public', priority: 8)
+        items.concat collect_sql(glob: adapter_root.join('public', '*.sql'), schema: 'public', priority: 9)
+        items
+      end
+
+      def collect_sql(glob:, schema:, priority:)
+        Dir.glob(glob.to_s).filter_map do |path|
+          base = File.basename(path)
+          next if base.start_with?('_')
+
+          { schema: schema, base: base, path: path, priority: priority }
+        end
+      end
+
+      def finalize_items(items)
+        chosen = {}
+
+        items.each do |item|
+          key = "#{item[:schema]}/#{item[:base]}"
+          prev = chosen[key]
+          chosen[key] = item if prev.nil? || item[:priority] > prev[:priority]
+        end
+
+        chosen.values
+              .sort_by { |item| [item[:schema], item[:base]] }
+              .map { |item| item[:path] }
+      end
+
+      def adapter_root_for(conn, root)
+        case conn.class.name
+        when 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
+          root.join('postgresql')
+        when 'ActiveRecord::ConnectionAdapters::Mysql2Adapter',
+          'ActiveRecord::ConnectionAdapters::TrilogyAdapter'
+          root.join('mysql')
+        else
+          raise Arfi::Errors::AdapterNotSupported
+        end
+      end
+    end
+  end
+end

--- a/lib/arfi/tasks/db.rake
+++ b/lib/arfi/tasks/db.rake
@@ -3,12 +3,12 @@
 require 'rake'
 require 'active_record'
 require 'arfi/sql_function_loader'
+require 'arfi/sql_trigger_loader'
 
 namespace :_db do
   task :arfi_enhance do
-    # For non-suffixed tasks (db:migrate / db:prepare etc),
-    # loader will populate all DBs when multi-db and task_name is nil.
     Arfi::SqlFunctionLoader.load!(verbose: true)
+    Arfi::SqlTriggerLoader.load!(verbose: true)
   end
 end
 
@@ -56,6 +56,11 @@ end
 
 def run_arfi_loader(task)
   Arfi::SqlFunctionLoader.load!(
+    task_name: task.name,
+    connection: ActiveRecord::Base.connection,
+    verbose: true
+  )
+  Arfi::SqlTriggerLoader.load!(
     task_name: task.name,
     connection: ActiveRecord::Base.connection,
     verbose: true

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -137,6 +137,10 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: dbm
+  version: '0'
+  source:
+    type: stdlib
 - name: delegate
   version: '0'
   source:
@@ -317,6 +321,14 @@ gems:
   version: 1.9.0
   source:
     type: rubygems
+- name: pstore
+  version: '0'
+  source:
+    type: stdlib
+- name: psych
+  version: '0'
+  source:
+    type: stdlib
 - name: rack
   version: '2.2'
   source:

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionmailer
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionpack
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actiontext
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionview
@@ -38,7 +38,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activejob
@@ -46,7 +46,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activemodel
@@ -54,7 +54,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activerecord
@@ -62,7 +62,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activestorage
@@ -70,7 +70,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activesupport
@@ -78,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -86,7 +86,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -98,7 +98,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: cgi
@@ -106,7 +106,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: concurrent-ruby
@@ -114,7 +114,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -122,7 +122,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -130,14 +130,10 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
-  version: '0'
-  source:
-    type: stdlib
-- name: dbm
   version: '0'
   source:
     type: stdlib
@@ -150,7 +146,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: digest
@@ -178,7 +174,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -186,7 +182,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: io-console
@@ -210,7 +206,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -222,7 +218,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: marcel
@@ -230,7 +226,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: mini_mime
@@ -238,7 +234,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: minitest
@@ -246,7 +242,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -262,7 +258,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: net-protocol
@@ -274,7 +270,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: nokogiri
@@ -282,7 +278,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: openssl
@@ -298,7 +294,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -306,7 +302,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: pp
@@ -318,23 +314,15 @@ gems:
   source:
     type: stdlib
 - name: prism
-  version: 1.8.0
+  version: 1.9.0
   source:
     type: rubygems
-- name: pstore
-  version: '0'
-  source:
-    type: stdlib
-- name: psych
-  version: '0'
-  source:
-    type: stdlib
 - name: rack
   version: '2.2'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-dom-testing
@@ -342,7 +330,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-html-sanitizer
@@ -350,7 +338,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: railties
@@ -358,7 +346,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -366,7 +354,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -374,7 +362,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rbs
@@ -390,7 +378,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -402,7 +390,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -410,7 +398,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-sorted_methods_by_call
@@ -446,7 +434,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -466,7 +454,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri
@@ -478,7 +466,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d07edeb13c53de1c65b2bede98a720ac52d497a2
+    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/sig/compat/active_record_base_compat.rbs
+++ b/sig/compat/active_record_base_compat.rbs
@@ -5,6 +5,8 @@ module ActiveRecord
     def self.clear_active_connections!: () -> void
 
     def self.configurations: () -> ::ActiveRecord::DatabaseConfigurations
+
+    def self.connection_db_config: () -> ::ActiveRecord::DatabaseConfigurations::DatabaseConfig
   end
 
   class DatabaseConfigurations::DatabaseConfig

--- a/sig/lib/arfi/commands/triggers.rbs
+++ b/sig/lib/arfi/commands/triggers.rbs
@@ -1,0 +1,70 @@
+module Arfi
+  module Commands
+    TRIGGERS_ROOT_DIR: "db/triggers"
+
+    class Triggers < Thor
+      # steep:ignore:end
+      def create: (String trigger_ref) -> void
+
+      # steep:ignore:end
+      def destroy: (String trigger_ref) -> void
+
+      # steep:ignore:end
+      def list: () -> void
+
+      private
+
+      def validate_schema_format!: () -> void
+
+      def validate_adapter_option!: () -> void
+
+      def parse_trigger_ref: (String ref) -> [String?, String]
+
+      def schema_opt: () -> String?
+
+      def validate_identifiers!: (String? schema, String trigger_name) -> void
+
+      def ensure_dirs!: (adapter: String?, schema: String?) -> void
+
+      def build_sql_trigger: (String? schema, String trigger_name, original_ref: String) -> String
+
+      def build_from_file: (String? schema, String trigger_name, original_ref: String) -> String
+
+      def write_file: (String? schema, String trigger_name, String content) -> void
+
+      def canonical_path: (String? schema, String trigger_name) -> String
+
+      def trigger_paths: (String? schema, String trigger_name) -> Array[String]
+
+      def adapter_opt: () -> String?
+
+      def infer_adapter_from_config: () -> String?
+
+      def resolve_triggers_for: (adapter: String) -> Array[::Hash[Symbol, untyped]]
+
+      def collect_candidates: (glob: ::Pathname, schema: String, source: String, origin: String, priority: Integer) -> Array[candidate]
+
+      def print_table: (Array[resolved_row] rows) -> void
+
+      def rel: (::Pathname | String path) -> String
+
+      def remove_trigger_file: (String? schema, String trigger_name) -> void
+
+      def resolve_adapter: () -> String
+
+      def render_list: (Array[::Hash[Symbol, untyped]] rows) -> void
+
+      def resolve_key_group: (Array[candidate] arr) -> Array[::Hash[Symbol, untyped]]
+
+      def resolve_schema_name: (String? schema) -> String?
+
+      def collect_all_candidates: (::Pathname root, String adapter) -> Array[candidate]
+
+      def group_candidates_by_key: (Array[candidate] candidates) -> ::Hash[String, Array[candidate]]
+
+      def build_resolved_rows: (::Hash[String, Array[candidate]] by_key) -> Array[::Hash[Symbol, untyped]]
+
+      def validate_trigger_ref!: (String ref) -> void
+    end
+  end
+end

--- a/sig/lib/arfi/commands/triggers.rbs
+++ b/sig/lib/arfi/commands/triggers.rbs
@@ -2,6 +2,29 @@ module Arfi
   module Commands
     TRIGGERS_ROOT_DIR: "db/triggers"
 
+    type trigger_candidate = {
+      key: String,
+      schema: String,
+      trigger: String,
+      source: String,
+      origin: String,
+      priority: Integer,
+      path: String
+    }
+
+    type trigger_resolved_row = {
+      key: String,
+      schema: String,
+      trigger: String,
+      source: String,
+      origin: String,
+      priority: Integer,
+      path: String,
+      ?chosen: bool,
+      ?shadowed: Array[String],
+      ?shadowed_by: String?
+    }
+
     class Triggers < Thor
       # steep:ignore:end
       def create: (String trigger_ref) -> void
@@ -40,11 +63,11 @@ module Arfi
 
       def infer_adapter_from_config: () -> String?
 
-      def resolve_triggers_for: (adapter: String) -> Array[::Hash[Symbol, untyped]]
+      def resolve_triggers_for: (adapter: String) -> Array[trigger_resolved_row]
 
-      def collect_candidates: (glob: ::Pathname, schema: String, source: String, origin: String, priority: Integer) -> Array[candidate]
+      def collect_candidates: (glob: ::Pathname, schema: String, source: String, origin: String, priority: Integer) -> Array[trigger_candidate]
 
-      def print_table: (Array[resolved_row] rows) -> void
+      def print_table: (Array[trigger_resolved_row] rows) -> void
 
       def rel: (::Pathname | String path) -> String
 
@@ -52,17 +75,17 @@ module Arfi
 
       def resolve_adapter: () -> String
 
-      def render_list: (Array[::Hash[Symbol, untyped]] rows) -> void
+      def render_list: (Array[trigger_resolved_row] rows) -> void
 
-      def resolve_key_group: (Array[candidate] arr) -> Array[::Hash[Symbol, untyped]]
+      def resolve_key_group: (Array[trigger_candidate] arr) -> Array[trigger_resolved_row]
 
       def resolve_schema_name: (String? schema) -> String?
 
-      def collect_all_candidates: (::Pathname root, String adapter) -> Array[candidate]
+      def collect_all_candidates: (::Pathname root, String adapter) -> Array[trigger_candidate]
 
-      def group_candidates_by_key: (Array[candidate] candidates) -> ::Hash[String, Array[candidate]]
+      def group_candidates_by_key: (Array[trigger_candidate] candidates) -> ::Hash[String, Array[trigger_candidate]]
 
-      def build_resolved_rows: (::Hash[String, Array[candidate]] by_key) -> Array[::Hash[Symbol, untyped]]
+      def build_resolved_rows: (::Hash[String, Array[trigger_candidate]] by_key) -> Array[trigger_resolved_row]
 
       def validate_trigger_ref!: (String ref) -> void
     end

--- a/sig/lib/arfi/commands/triggers_candidates.rbs
+++ b/sig/lib/arfi/commands/triggers_candidates.rbs
@@ -3,19 +3,19 @@ module Arfi
     module TriggersCandidates : Arfi::Commands::Triggers
       private
 
-      def collect_all_candidates: (::Pathname root, String adapter) -> Array[candidate]
+      def collect_all_candidates: (::Pathname root, String adapter) -> Array[trigger_candidate]
 
-      def group_candidates_by_key: (Array[candidate] candidates) -> ::Hash[String, Array[candidate]]
+      def group_candidates_by_key: (Array[trigger_candidate] candidates) -> ::Hash[String, Array[trigger_candidate]]
 
-      def build_resolved_rows: (::Hash[String, Array[candidate]] by_key) -> Array[::Hash[Symbol, untyped]]
+      def build_resolved_rows: (::Hash[String, Array[trigger_candidate]] by_key) -> Array[trigger_resolved_row]
 
-      def generic_candidates: (::Pathname root) -> Array[candidate]
+      def generic_candidates: (::Pathname root) -> Array[trigger_candidate]
 
-      def adapter_candidates: (::Pathname adapter_root, String adapter) -> Array[candidate]
+      def adapter_candidates: (::Pathname adapter_root, String adapter) -> Array[trigger_candidate]
 
-      def collect_postgresql_schema_candidates: (::Pathname adapter_root, String adapter) -> Array[candidate]
+      def collect_postgresql_schema_candidates: (::Pathname adapter_root, String adapter) -> Array[trigger_candidate]
 
-      def collect_candidates: (glob: ::Pathname, schema: String, source: String, origin: String, priority: Integer) -> Array[candidate]
+      def collect_candidates: (glob: ::Pathname, schema: String, source: String, origin: String, priority: Integer) -> Array[trigger_candidate]
 
       def rel: (::Pathname | String path) -> String
     end

--- a/sig/lib/arfi/commands/triggers_candidates.rbs
+++ b/sig/lib/arfi/commands/triggers_candidates.rbs
@@ -1,0 +1,23 @@
+module Arfi
+  module Commands
+    module TriggersCandidates : Arfi::Commands::Triggers
+      private
+
+      def collect_all_candidates: (::Pathname root, String adapter) -> Array[candidate]
+
+      def group_candidates_by_key: (Array[candidate] candidates) -> ::Hash[String, Array[candidate]]
+
+      def build_resolved_rows: (::Hash[String, Array[candidate]] by_key) -> Array[::Hash[Symbol, untyped]]
+
+      def generic_candidates: (::Pathname root) -> Array[candidate]
+
+      def adapter_candidates: (::Pathname adapter_root, String adapter) -> Array[candidate]
+
+      def collect_postgresql_schema_candidates: (::Pathname adapter_root, String adapter) -> Array[candidate]
+
+      def collect_candidates: (glob: ::Pathname, schema: String, source: String, origin: String, priority: Integer) -> Array[candidate]
+
+      def rel: (::Pathname | String path) -> String
+    end
+  end
+end

--- a/sig/lib/arfi/commands/triggers_creation.rbs
+++ b/sig/lib/arfi/commands/triggers_creation.rbs
@@ -1,0 +1,23 @@
+module Arfi
+  module Commands
+    module TriggersCreation : Arfi::Commands::Triggers
+      private
+
+      def ensure_dirs!: (adapter: String?, schema: String?) -> void
+
+      def build_sql_trigger: (String? schema, String trigger_name, original_ref: String) -> String
+
+      def build_from_file: (String? schema, String trigger_name, original_ref: String) -> String
+
+      def write_file: (String? schema, String trigger_name, String content) -> void
+
+      def remove_trigger_file: (String? schema, String trigger_name) -> void
+
+      def evaluate_template: (String trigger_name, String? schema_name, String qualified_name, String original_ref) -> untyped
+
+      def build_postgresql_trigger_skeleton: (String? schema, String trigger_name) -> String
+
+      def build_mysql_trigger_skeleton: (String trigger_name) -> String
+    end
+  end
+end

--- a/sig/lib/arfi/commands/triggers_creation.rbs
+++ b/sig/lib/arfi/commands/triggers_creation.rbs
@@ -18,6 +18,18 @@ module Arfi
       def build_postgresql_trigger_skeleton: (String? schema, String trigger_name) -> String
 
       def build_mysql_trigger_skeleton: (String trigger_name) -> String
+
+      def pg_trigger_sql: (String trigger_name, String sch, String fn_name) -> String
+
+      def pg_table: () -> String
+
+      def pg_timing: () -> String
+
+      def pg_for_each: () -> String
+
+      def pg_trigger_events: () -> String
+
+      def mysql_trigger_sql: (String trigger_name, String timing, String event, String table) -> String
     end
   end
 end

--- a/sig/lib/arfi/commands/triggers_helpers.rbs
+++ b/sig/lib/arfi/commands/triggers_helpers.rbs
@@ -21,7 +21,7 @@ module Arfi
 
       def resolve_adapter: () -> String
 
-      def resolve_triggers_for: (adapter: String) -> Array[::Hash[Symbol, untyped]]
+      def resolve_triggers_for: (adapter: String) -> Array[trigger_resolved_row]
 
       def adapter_opt: () -> String?
 

--- a/sig/lib/arfi/commands/triggers_helpers.rbs
+++ b/sig/lib/arfi/commands/triggers_helpers.rbs
@@ -1,0 +1,33 @@
+module Arfi
+  module Commands
+    module TriggersHelpers : Arfi::Commands::Triggers
+      private
+
+      def validate_schema_format!: () -> void
+
+      def validate_adapter_option!: () -> void
+
+      def parse_trigger_ref: (String ref) -> [String?, String]
+
+      def schema_opt: () -> String?
+
+      def validate_identifiers!: (String? schema, String trigger_name) -> void
+
+      def validate_trigger_ref!: (String ref) -> void
+
+      def check_schema_conflict!: (String? parsed_schema) -> void
+
+      def resolve_schema_name: (String? schema) -> String?
+
+      def resolve_adapter: () -> String
+
+      def resolve_triggers_for: (adapter: String) -> Array[::Hash[Symbol, untyped]]
+
+      def adapter_opt: () -> String?
+
+      def infer_adapter_from_config: () -> String?
+
+      def primary_db_config: () -> untyped
+    end
+  end
+end

--- a/sig/lib/arfi/commands/triggers_paths.rbs
+++ b/sig/lib/arfi/commands/triggers_paths.rbs
@@ -1,0 +1,21 @@
+module Arfi
+  module Commands
+    module TriggersPaths : Arfi::Commands::Triggers
+      private
+
+      def canonical_path: (String? schema, String trigger_name) -> String
+
+      def trigger_paths: (String? schema, String trigger_name) -> Array[String]
+
+      def generic_canonical_path: (::Pathname root, String? schema, String trigger_name) -> String
+
+      def adapter_canonical_path: (::Pathname root, String? schema, String trigger_name) -> String
+
+      def generic_trigger_paths: (::Pathname root, String trigger_name) -> Array[String]
+
+      def postgresql_trigger_paths: (::Pathname root, String? schema, String trigger_name) -> Array[String]
+
+      def mysql_trigger_paths: (::Pathname root, String trigger_name) -> Array[String]
+    end
+  end
+end

--- a/sig/lib/arfi/commands/triggers_rendering.rbs
+++ b/sig/lib/arfi/commands/triggers_rendering.rbs
@@ -3,23 +3,23 @@ module Arfi
     module TriggersRendering : Arfi::Commands::Triggers
       private
 
-      def render_list: (Array[::Hash[Symbol, untyped]] rows) -> void
+      def render_list: (Array[trigger_resolved_row] rows) -> void
 
-      def print_table: (Array[resolved_row] rows) -> void
+      def print_table: (Array[trigger_resolved_row] rows) -> void
 
       def table_columns: () -> Array[String]
 
-      def stringify_rows: (Array[resolved_row] rows) -> Array[resolved_row]
+      def stringify_rows: (Array[trigger_resolved_row] rows) -> Array[trigger_resolved_row]
 
-      def calculate_widths: (Array[String] cols, Array[resolved_row] table) -> ::Hash[String, Integer]
+      def calculate_widths: (Array[String] cols, Array[trigger_resolved_row] table) -> ::Hash[String, Integer]
 
-      def render_table_rows: (Array[resolved_row] table, Array[String] cols, ::Hash[String, Integer] widths) -> void
+      def render_table_rows: (Array[trigger_resolved_row] table, Array[String] cols, ::Hash[String, Integer] widths) -> void
 
-      def resolve_key_group: (Array[candidate] arr) -> Array[::Hash[Symbol, untyped]]
+      def resolve_key_group: (Array[trigger_candidate] arr) -> Array[trigger_resolved_row]
 
-      def all_mode_rows: (Array[candidate] arr, candidate chosen) -> Array[::Hash[Symbol, untyped]]
+      def all_mode_rows: (Array[trigger_candidate] arr, trigger_candidate chosen) -> Array[trigger_resolved_row]
 
-      def default_mode_row: (candidate chosen, Array[candidate] arr) -> Array[::Hash[Symbol, untyped]]
+      def default_mode_row: (trigger_candidate chosen, Array[trigger_candidate] arr) -> Array[trigger_resolved_row]
     end
   end
 end

--- a/sig/lib/arfi/commands/triggers_rendering.rbs
+++ b/sig/lib/arfi/commands/triggers_rendering.rbs
@@ -1,0 +1,25 @@
+module Arfi
+  module Commands
+    module TriggersRendering : Arfi::Commands::Triggers
+      private
+
+      def render_list: (Array[::Hash[Symbol, untyped]] rows) -> void
+
+      def print_table: (Array[resolved_row] rows) -> void
+
+      def table_columns: () -> Array[String]
+
+      def stringify_rows: (Array[resolved_row] rows) -> Array[resolved_row]
+
+      def calculate_widths: (Array[String] cols, Array[resolved_row] table) -> ::Hash[String, Integer]
+
+      def render_table_rows: (Array[resolved_row] table, Array[String] cols, ::Hash[String, Integer] widths) -> void
+
+      def resolve_key_group: (Array[candidate] arr) -> Array[::Hash[Symbol, untyped]]
+
+      def all_mode_rows: (Array[candidate] arr, candidate chosen) -> Array[::Hash[Symbol, untyped]]
+
+      def default_mode_row: (candidate chosen, Array[candidate] arr) -> Array[::Hash[Symbol, untyped]]
+    end
+  end
+end

--- a/sig/lib/arfi/errors.rbs
+++ b/sig/lib/arfi/errors.rbs
@@ -17,5 +17,11 @@ module Arfi
 
       def initialize: (?::String message) -> void
     end
+
+    class NoTriggersDir < StandardError
+      @message: string
+
+      def initialize: (?::String message) -> void
+    end
   end
 end

--- a/sig/lib/arfi/extensions/active_record/base.rbs
+++ b/sig/lib/arfi/extensions/active_record/base.rbs
@@ -5,5 +5,11 @@ module ActiveRecord
     def self.pg_function_exists?: (String function_name) -> bool
 
     def self.mysql_function_exists?: (String function_name) -> bool
+
+    def self.trigger_exists?: (String table, String trigger_name) -> bool
+
+    def self.pg_trigger_exists?: (String table, String trigger_name) -> bool
+
+    def self.mysql_trigger_exists?: (String table, String trigger_name) -> bool
   end
 end

--- a/sig/lib/arfi/sql_trigger_loader.rbs
+++ b/sig/lib/arfi/sql_trigger_loader.rbs
@@ -1,0 +1,45 @@
+module Arfi
+  class SqlTriggerLoader
+    def self.load!: (?task_name: String?, ?connection: ::ActiveRecord::ConnectionAdapters::AbstractAdapter?, ?clear_active_connections: bool, ?verbose: bool) -> void
+
+    private
+
+    def self.default_connection: () -> ::ActiveRecord::ConnectionAdapters::AbstractAdapter
+
+    def self.raise_unless_supported_adapter: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> void
+
+    def self.multi_db?: () -> bool
+
+    def self.populate_multiple_db: (verbose: bool, ?task_name: String?) -> void
+
+    def self.current_db_config: () -> untyped
+
+    def self.populate_db: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, verbose: bool, task_name: String?) -> void
+
+    def self.clear_active_connections_if_needed: (bool clear) -> void
+
+    def self.load_sql_file: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, ::Pathname | String file, bool verbose, String? task_name) -> void
+
+    def self.log_sql_load: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, ::Pathname | String file, String? task_name) -> void
+
+    def self.safe_db_env: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> String
+
+    def self.safe_db_name: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> String
+
+    def self.log: (::ActiveRecord::ConnectionAdapters::AbstractAdapter _conn, String msg) -> void
+
+    def self.sql_files: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> Array[String]
+
+    def self.collect_adapter_sql_files: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, ::Pathname adapter_root) -> Array[sql_file_item]
+
+    def self.collect_postgresql_sql_files: (::Pathname adapter_root) -> Array[sql_file_item]
+
+    def self.collect_adapter_public_sql_files: (::Pathname adapter_root) -> Array[sql_file_item]
+
+    def self.collect_sql: (glob: ::Pathname | String, schema: String, priority: Integer) -> Array[sql_file_item]
+
+    def self.finalize_items: (Array[sql_file_item] items) -> Array[String]
+
+    def self.adapter_root_for: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, ::Pathname root) -> ::Pathname
+  end
+end

--- a/spec/arfi/commands/functions_list_spec.rb
+++ b/spec/arfi/commands/functions_list_spec.rb
@@ -8,21 +8,21 @@ RSpec.describe Arfi::Commands::Functions do
   it 'prints effective file paths (adapter overrides generic)' do
     write_function('db/functions/public/arfi_echo.sql')
     write_function('db/functions/postgresql/public/arfi_echo.sql')
-    expect { described_class.start(['list', '--adapter=postgresql', '--format=paths']) }
+    expect { described_class.start(%w[list --adapter=postgresql --format=paths]) }
       .to output(%r{db/functions/postgresql/public/arfi_echo\.sql}).to_stdout
   end
 
   it 'ignores underscore-prefixed sql files' do
     write_function('db/functions/public/_boom.sql', 'SELECT 1/0;')
     write_function('db/functions/public/ok.sql')
-    expect { described_class.start(['list', '--adapter=postgresql', '--format=paths']) }
+    expect { described_class.start(%w[list --adapter=postgresql --format=paths]) }
       .to output(%r{db/functions/public/ok\.sql}).to_stdout
   end
 
   it 'shows shadowed candidates with --all' do
     write_function('db/functions/public/arfi_echo.sql')
     write_function('db/functions/postgresql/public/arfi_echo.sql')
-    expect { described_class.start(['list', '--adapter=postgresql', '--all', '--format=table']) }
+    expect { described_class.start(%w[list --adapter=postgresql --all --format=table]) }
       .to output(/chosen|shadowed_by/).to_stdout
   end
 end

--- a/spec/arfi/postgre_sql/database_statements_patch_spec.rb
+++ b/spec/arfi/postgre_sql/database_statements_patch_spec.rb
@@ -5,10 +5,6 @@ require 'rails_helper'
 RSpec.describe Arfi::PostgreSQL::DatabaseStatementsPatch, :pgsql do
   include ArfiSpec::TmpRoot
 
-  def load!
-    Arfi::SqlFunctionLoader.load!(verbose: false)
-  end
-
   before do
     write_function('db/functions/postgresql/public/arfi_auto.sql', <<~SQL)
       CREATE OR REPLACE FUNCTION arfi_auto() RETURNS int
@@ -18,7 +14,7 @@ RSpec.describe Arfi::PostgreSQL::DatabaseStatementsPatch, :pgsql do
   end
 
   it 'reloads functions and retries when a managed function is missing' do
-    load!
+    load_functions!
     val = ActiveRecord::Base.connection.select_value('SELECT arfi_auto()')
     expect(val).to eq(42)
   end

--- a/spec/arfi/sql_function_loader_functional_index_flow_spec.rb
+++ b/spec/arfi/sql_function_loader_functional_index_flow_spec.rb
@@ -14,24 +14,12 @@ RSpec.describe Arfi::SqlFunctionLoader, :pgsql do
     SQL
   end
 
-  def load!
-    described_class.load!(verbose: false)
-  end
-
-  def expect_index_creation_to_succeed
-    expect do
-      ActiveRecord::Base.connection.execute(<<~SQL)
-        CREATE INDEX idx_users_norm_email ON users (normalize_email(email));
-      SQL
-    end.not_to raise_error
-  end
-
   it 'succeeds via auto-reload when function is ARFI-managed' do
     expect_index_creation_to_succeed
   end
 
   it 'succeeds after loader provides the function' do
-    load!
+    load_functions!
     expect_index_creation_to_succeed
   end
 end

--- a/spec/arfi/sql_function_loader_multi_db_spec.rb
+++ b/spec/arfi/sql_function_loader_multi_db_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe Arfi::SqlFunctionLoader, :pgsql do
     SQL
   end
 
-  def db_config(**extra)
-    { 'adapter' => 'postgresql', 'url' => ENV.fetch('ARFI_POSTGRES_URL') }.merge(extra)
-  end
-
   let(:db_configs) do
     {
       'test' => {
@@ -30,55 +26,40 @@ RSpec.describe Arfi::SqlFunctionLoader, :pgsql do
     }
   end
 
-  def with_temp_configs(configs)
-    old = ActiveRecord::Base.configurations
-    ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new(configs)
-    described_class.load!(verbose: false)
-    yield
-  ensure
-    ActiveRecord::Base.configurations = old
-  end
-
   it 'loads functions into primary database' do
-    with_temp_configs(db_configs) do
+    with_db_configs(db_configs) do
       ActiveRecord::Base.establish_connection(db_configs['test']['primary'])
+      load_functions!
       expect(ActiveRecord::Base.connection.select_value('SELECT arfi_multi()')).to eq('arfi_primary')
     end
   end
 
   it 'loads functions into animals database' do
-    with_temp_configs(db_configs) do
+    with_db_configs(db_configs) do
       ActiveRecord::Base.establish_connection(db_configs['test']['animals'])
+      load_functions!
       expect(ActiveRecord::Base.connection.select_value('SELECT arfi_multi()')).to eq('arfi_animals')
     end
   end
 
-  def with_multi_db_configs
-    old = ActiveRecord::Base.configurations
-    ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new(db_configs)
-    yield
-  ensure
-    ActiveRecord::Base.configurations = old
-  end
-
   it 'restores the original connection config after multi-db loading' do
-    with_multi_db_configs do
+    with_db_configs(db_configs) do
       original = ActiveRecord::Base.connection_db_config.name
-      described_class.load!(verbose: false)
+      load_functions!
       expect(ActiveRecord::Base.connection_db_config.name).to eq(original)
     end
   end
 
   it 'leaves the original connection functional after multi-db loading' do
-    with_multi_db_configs do
+    with_db_configs(db_configs) do
       ActiveRecord::Base.connection.select_value('SELECT 1')
-      described_class.load!(verbose: false)
+      load_functions!
       expect(ActiveRecord::Base.connection.select_value('SELECT 1')).to eq(1)
     end
   end
 
   it 'skips clear_active_connections when disabled' do
-    with_multi_db_configs do
+    with_db_configs(db_configs) do
       allow(ActiveRecord::Base.connection_handler).to receive(:clear_active_connections!)
       described_class.load!(verbose: false, clear_active_connections: false)
       expect(ActiveRecord::Base.connection_handler).not_to have_received(:clear_active_connections!)

--- a/spec/arfi/sql_function_loader_mysql_spec.rb
+++ b/spec/arfi/sql_function_loader_mysql_spec.rb
@@ -3,14 +3,6 @@
 RSpec.describe Arfi::SqlFunctionLoader, :mysql do
   include ArfiSpec::TmpRoot
 
-  def load!
-    described_class.load!(verbose: false)
-  end
-
-  def select_value(sql)
-    ActiveRecord::Base.connection.select_value(sql)
-  end
-
   before do
     write_function('db/functions/mysql/public/arfi_ok.sql', <<~SQL)
       CREATE FUNCTION arfi_ok() RETURNS INT DETERMINISTIC RETURN 1;
@@ -18,13 +10,13 @@ RSpec.describe Arfi::SqlFunctionLoader, :mysql do
   end
 
   it 'loads mysql/public functions' do
-    load!
+    load_functions!
     expect(select_value('SELECT arfi_ok()').to_i).to eq(1)
   end
 
   it 'ignores underscore-prefixed files' do
     write_function('db/functions/mysql/public/_boom.sql', 'SELECT 1/0;')
-    load!
+    load_functions!
     expect(select_value('SELECT arfi_ok()').to_i).to eq(1)
   end
 
@@ -39,7 +31,7 @@ RSpec.describe Arfi::SqlFunctionLoader, :mysql do
     end
 
     it 'prefers adapter file over generic' do
-      load!
+      load_functions!
       expect(select_value('SELECT arfi_echo()')).to eq('mysql')
     end
   end

--- a/spec/arfi/sql_function_loader_postgresql_schema_dir_spec.rb
+++ b/spec/arfi/sql_function_loader_postgresql_schema_dir_spec.rb
@@ -5,24 +5,16 @@ require 'rails_helper'
 RSpec.describe Arfi::SqlFunctionLoader, :pgsql do
   include ArfiSpec::TmpRoot
 
-  def load!
-    described_class.load!(verbose: false)
-  end
-
-  def write_schema_function(rel, sql)
-    root.join(rel).tap { |p| FileUtils.mkdir_p(p.dirname) }.write(sql)
-  end
-
   before do
     ActiveRecord::Base.connection.execute('CREATE SCHEMA IF NOT EXISTS audit;')
-    write_schema_function('db/functions/postgresql/audit/arfi_audit.sql', <<~SQL)
+    write_function('db/functions/postgresql/audit/arfi_audit.sql', <<~SQL)
       CREATE OR REPLACE FUNCTION audit.arfi_audit() RETURNS int
       LANGUAGE sql IMMUTABLE AS $$ SELECT 7; $$;
     SQL
   end
 
   it 'loads functions from db/functions/postgresql/<schema>' do
-    load!
+    load_functions!
     expect(ActiveRecord::Base.connection.select_value('SELECT audit.arfi_audit()')).to eq(7)
   end
 end

--- a/spec/arfi/sql_function_loader_spec.rb
+++ b/spec/arfi/sql_function_loader_spec.rb
@@ -3,14 +3,6 @@
 RSpec.describe Arfi::SqlFunctionLoader, :pgsql do
   include ArfiSpec::TmpRoot
 
-  def load!
-    described_class.load!(verbose: false)
-  end
-
-  def select_value(sql)
-    ActiveRecord::Base.connection.select_value(sql)
-  end
-
   before do
     write_function('db/functions/public/arfi_echo.sql', <<~SQL)
       CREATE OR REPLACE FUNCTION arfi_echo() RETURNS text
@@ -19,7 +11,7 @@ RSpec.describe Arfi::SqlFunctionLoader, :pgsql do
   end
 
   it 'loads generic functions from db/functions' do
-    load!
+    load_functions!
     expect(select_value('SELECT arfi_echo()')).to eq('generic')
   end
 
@@ -32,7 +24,7 @@ RSpec.describe Arfi::SqlFunctionLoader, :pgsql do
     end
 
     it 'prefers adapter-specific override db/functions/postgresql over db/functions' do
-      load!
+      load_functions!
       expect(select_value('SELECT arfi_echo()')).to eq('postgres')
     end
   end
@@ -47,7 +39,7 @@ RSpec.describe Arfi::SqlFunctionLoader, :pgsql do
     end
 
     it 'ignores underscore-prefixed sql files' do
-      load!
+      load_functions!
       expect(select_value('SELECT arfi_ok()')).to eq(1)
     end
   end

--- a/spec/arfi/sql_function_loader_tasks_db_spec.rb
+++ b/spec/arfi/sql_function_loader_tasks_db_spec.rb
@@ -18,14 +18,6 @@ RSpec.describe Arfi::SqlFunctionLoader do
     Rake.application = nil
   end
 
-  def define_tasks(*names)
-    names.each { |n| Rake::Task.define_task(n) }
-  end
-
-  def load_arfi_tasks
-    load File.expand_path('../../lib/arfi/tasks/db.rake', __dir__)
-  end
-
   describe 'standard db tasks' do
     before do
       define_tasks('db:migrate', 'db:schema:load', 'db:setup', 'db:prepare', 'db:test:prepare')

--- a/spec/arfi/sql_function_loader_tasks_db_spec.rb
+++ b/spec/arfi/sql_function_loader_tasks_db_spec.rb
@@ -64,12 +64,20 @@ RSpec.describe Arfi::SqlFunctionLoader do
       allow(configs).to receive(:configs_for).and_return([])
       allow(ActiveRecord::Base).to receive_messages(connection: Object.new, configurations: configs)
       allow(described_class).to receive(:load!)
+      allow(Arfi::SqlTriggerLoader).to receive(:load!)
       load_arfi_tasks
     end
 
     it 'calls SqlFunctionLoader with task_name' do
       Rake::Task['_db:arfi_enhance:db:migrate:animals'].invoke
       expect(described_class).to have_received(:load!).with(
+        task_name: 'db:migrate:animals', connection: anything, verbose: true
+      )
+    end
+
+    it 'calls SqlTriggerLoader with task_name' do
+      Rake::Task['_db:arfi_enhance:db:migrate:animals'].invoke
+      expect(Arfi::SqlTriggerLoader).to have_received(:load!).with(
         task_name: 'db:migrate:animals', connection: anything, verbose: true
       )
     end

--- a/spec/arfi/sql_trigger_loader_mysql_spec.rb
+++ b/spec/arfi/sql_trigger_loader_mysql_spec.rb
@@ -3,14 +3,6 @@
 RSpec.describe Arfi::SqlTriggerLoader, :mysql do
   include ArfiSpec::TmpRoot
 
-  def load!
-    described_class.load!(verbose: false)
-  end
-
-  def select_value(sql)
-    ActiveRecord::Base.connection.select_value(sql)
-  end
-
   before do
     write_function('db/functions/public/users.sql', <<~SQL)
       CREATE TABLE IF NOT EXISTS users (id serial PRIMARY KEY, name varchar(255));
@@ -18,25 +10,16 @@ RSpec.describe Arfi::SqlTriggerLoader, :mysql do
     Arfi::SqlFunctionLoader.load!(verbose: false)
   end
 
-  def mysql_trigger_sql(name)
-    <<~SQL
-      CREATE TRIGGER #{name}
-        BEFORE INSERT ON users
-        FOR EACH ROW
-        SET NEW.name = 'triggered';
-    SQL
-  end
-
   it 'loads mysql triggers from db/triggers/mysql/public' do
     write_function('db/triggers/mysql/public/arfi_before_ins.sql', mysql_trigger_sql('arfi_before_ins'))
-    load!
+    load_triggers!
     expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_before_ins')).to be(true)
   end
 
   it 'ignores underscore-prefixed files' do
     write_function('db/triggers/mysql/public/_boom.sql', 'SELECT 1/0;')
     write_function('db/triggers/mysql/public/arfi_before_ins.sql', mysql_trigger_sql('arfi_before_ins'))
-    load!
+    load_triggers!
     expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_before_ins')).to be(true)
   end
 
@@ -57,7 +40,7 @@ RSpec.describe Arfi::SqlTriggerLoader, :mysql do
     end
 
     it 'prefers adapter file over generic' do
-      load!
+      load_triggers!
       expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_echo')).to be(true)
     end
   end

--- a/spec/arfi/sql_trigger_loader_mysql_spec.rb
+++ b/spec/arfi/sql_trigger_loader_mysql_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe Arfi::SqlTriggerLoader, :mysql do
+  include ArfiSpec::TmpRoot
+
+  def load!
+    described_class.load!(verbose: false)
+  end
+
+  def select_value(sql)
+    ActiveRecord::Base.connection.select_value(sql)
+  end
+
+  before do
+    write_function('db/functions/public/users.sql', <<~SQL)
+      CREATE TABLE IF NOT EXISTS users (id serial PRIMARY KEY, name varchar(255));
+    SQL
+    Arfi::SqlFunctionLoader.load!(verbose: false)
+  end
+
+  def mysql_trigger_sql(name)
+    <<~SQL
+      CREATE TRIGGER #{name}
+        BEFORE INSERT ON users
+        FOR EACH ROW
+        SET NEW.name = 'triggered';
+    SQL
+  end
+
+  it 'loads mysql triggers from db/triggers/mysql/public' do
+    write_function('db/triggers/mysql/public/arfi_before_ins.sql', mysql_trigger_sql('arfi_before_ins'))
+    load!
+    expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_before_ins')).to be(true)
+  end
+
+  it 'ignores underscore-prefixed files' do
+    write_function('db/triggers/mysql/public/_boom.sql', 'SELECT 1/0;')
+    write_function('db/triggers/mysql/public/arfi_before_ins.sql', mysql_trigger_sql('arfi_before_ins'))
+    load!
+    expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_before_ins')).to be(true)
+  end
+
+  context 'when adapter-specific and generic exist' do
+    before do
+      write_function('db/triggers/mysql/public/arfi_echo.sql', <<~SQL)
+        CREATE TRIGGER arfi_echo
+          BEFORE INSERT ON users
+          FOR EACH ROW
+          SET NEW.name = 'adapter';
+      SQL
+      write_function('db/triggers/public/arfi_echo.sql', <<~SQL)
+        CREATE TRIGGER arfi_echo
+          BEFORE INSERT ON users
+          FOR EACH ROW
+          SET NEW.name = 'generic';
+      SQL
+    end
+
+    it 'prefers adapter file over generic' do
+      load!
+      expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_echo')).to be(true)
+    end
+  end
+end

--- a/spec/arfi/sql_trigger_loader_spec.rb
+++ b/spec/arfi/sql_trigger_loader_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe Arfi::SqlTriggerLoader, :pgsql do
+  include ArfiSpec::TmpRoot
+
+  def load!
+    described_class.load!(verbose: false)
+  end
+
+  def select_value(sql)
+    ActiveRecord::Base.connection.select_value(sql)
+  end
+
+  before do
+    ActiveRecord::Base.connection.execute(<<~SQL)
+      CREATE OR REPLACE FUNCTION public.arfi_before_insert()
+      RETURNS TRIGGER
+      LANGUAGE plpgsql AS $$
+      BEGIN
+        RETURN NEW;
+      END;
+      $$;
+    SQL
+    write_function('db/functions/public/users.sql', <<~SQL)
+      CREATE TABLE IF NOT EXISTS users (id serial PRIMARY KEY, name text);
+    SQL
+  end
+
+  def trigger_sql(name)
+    <<~SQL
+      CREATE TRIGGER #{name}
+        BEFORE INSERT ON users
+        FOR EACH ROW
+        EXECUTE FUNCTION public.arfi_before_insert();
+    SQL
+  end
+
+  it 'loads triggers from db/triggers' do
+    write_function('db/triggers/public/arfi_before_ins.sql', trigger_sql('arfi_before_ins'))
+    Arfi::SqlFunctionLoader.load!(verbose: false)
+    load!
+    expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_before_ins')).to be(true)
+  end
+
+  it 'ignores underscore-prefixed files' do
+    write_function('db/triggers/public/_boom.sql', 'SELECT 1/0;')
+    write_function('db/triggers/public/arfi_before_ins.sql', trigger_sql('arfi_before_ins'))
+    Arfi::SqlFunctionLoader.load!(verbose: false)
+    load!
+    expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_before_ins')).to be(true)
+  end
+
+  context 'when adapter-specific override exists' do
+    before do
+      write_function('db/triggers/public/arfi_echo.sql', <<~SQL)
+        CREATE TRIGGER arfi_echo
+          BEFORE INSERT ON users
+          FOR EACH ROW
+          EXECUTE FUNCTION public.arfi_before_insert();
+      SQL
+      write_function('db/triggers/postgresql/public/arfi_echo.sql', <<~SQL)
+        CREATE TRIGGER arfi_echo
+          AFTER INSERT ON users
+          FOR EACH ROW
+          EXECUTE FUNCTION public.arfi_before_insert();
+      SQL
+    end
+
+    it 'prefers adapter-specific override' do
+      Arfi::SqlFunctionLoader.load!(verbose: false)
+      load!
+      expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_echo')).to be(true)
+    end
+  end
+end

--- a/spec/arfi/sql_trigger_loader_spec.rb
+++ b/spec/arfi/sql_trigger_loader_spec.rb
@@ -3,14 +3,6 @@
 RSpec.describe Arfi::SqlTriggerLoader, :pgsql do
   include ArfiSpec::TmpRoot
 
-  def load!
-    described_class.load!(verbose: false)
-  end
-
-  def select_value(sql)
-    ActiveRecord::Base.connection.select_value(sql)
-  end
-
   before do
     ActiveRecord::Base.connection.execute(<<~SQL)
       CREATE OR REPLACE FUNCTION public.arfi_before_insert()
@@ -26,19 +18,10 @@ RSpec.describe Arfi::SqlTriggerLoader, :pgsql do
     SQL
   end
 
-  def trigger_sql(name)
-    <<~SQL
-      CREATE TRIGGER #{name}
-        BEFORE INSERT ON users
-        FOR EACH ROW
-        EXECUTE FUNCTION public.arfi_before_insert();
-    SQL
-  end
-
   it 'loads triggers from db/triggers' do
     write_function('db/triggers/public/arfi_before_ins.sql', trigger_sql('arfi_before_ins'))
     Arfi::SqlFunctionLoader.load!(verbose: false)
-    load!
+    load_triggers!
     expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_before_ins')).to be(true)
   end
 
@@ -46,7 +29,7 @@ RSpec.describe Arfi::SqlTriggerLoader, :pgsql do
     write_function('db/triggers/public/_boom.sql', 'SELECT 1/0;')
     write_function('db/triggers/public/arfi_before_ins.sql', trigger_sql('arfi_before_ins'))
     Arfi::SqlFunctionLoader.load!(verbose: false)
-    load!
+    load_triggers!
     expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_before_ins')).to be(true)
   end
 
@@ -68,7 +51,7 @@ RSpec.describe Arfi::SqlTriggerLoader, :pgsql do
 
     it 'prefers adapter-specific override' do
       Arfi::SqlFunctionLoader.load!(verbose: false)
-      load!
+      load_triggers!
       expect(ActiveRecord::Base.trigger_exists?('users', 'arfi_echo')).to be(true)
     end
   end

--- a/spec/arfi/sql_trigger_loader_tasks_db_spec.rb
+++ b/spec/arfi/sql_trigger_loader_tasks_db_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe Arfi::SqlTriggerLoader do
+  let(:app) { Rake::Application.new }
+
+  before do
+    Rake.application = app
+    Rake::Task.define_task(:environment)
+  end
+
+  after do
+    Rake.application = nil
+  end
+
+  def define_tasks(*names)
+    names.each { |n| Rake::Task.define_task(n) }
+  end
+
+  def load_arfi_tasks
+    load File.expand_path('../../lib/arfi/tasks/db.rake', __dir__)
+  end
+
+  describe 'dynamic enhancer calls both loaders' do
+    before do
+      define_tasks('db:migrate:animals')
+      allow(ActiveRecord::Base).to receive(:establish_connection)
+      configs = instance_double(ActiveRecord::DatabaseConfigurations)
+      allow(configs).to receive(:configs_for).and_return([])
+      allow(ActiveRecord::Base).to receive_messages(connection: Object.new, configurations: configs)
+      allow(Arfi::SqlFunctionLoader).to receive(:load!)
+      allow(described_class).to receive(:load!)
+      load_arfi_tasks
+    end
+
+    it 'calls SqlTriggerLoader alongside SqlFunctionLoader' do
+      Rake::Task['_db:arfi_enhance:db:migrate:animals'].invoke
+      expect(described_class).to have_received(:load!).with(
+        task_name: 'db:migrate:animals', connection: anything, verbose: true
+      )
+    end
+  end
+end

--- a/spec/arfi/sql_trigger_loader_tasks_db_spec.rb
+++ b/spec/arfi/sql_trigger_loader_tasks_db_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe Arfi::SqlTriggerLoader do
     Rake.application = nil
   end
 
-  def define_tasks(*names)
-    names.each { |n| Rake::Task.define_task(n) }
-  end
-
-  def load_arfi_tasks
-    load File.expand_path('../../lib/arfi/tasks/db.rake', __dir__)
-  end
-
   describe 'dynamic enhancer calls both loaders' do
     before do
       define_tasks('db:migrate:animals')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,11 @@ ArfiSpec::PgSQLDB.connect!
 ArfiSpec::MySQLDB.connect! if defined?(ArfiSpec::MySQLDB)
 
 RSpec.configure do |config|
+  config.include ArfiSpec::DbHelpers
+  config.include ArfiSpec::FunctionLoaderHelpers
+  config.include ArfiSpec::TriggerLoaderHelpers
+  config.include ArfiSpec::RakeTaskHelpers
+
   config.filter_run_excluding :pgsql unless ArfiSpec::PgSQLDB.available?
   config.filter_run_excluding :mysql unless ArfiSpec::MySQLDB.available?
 

--- a/spec/support/db_helpers.rb
+++ b/spec/support/db_helpers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ArfiSpec
+  module DbHelpers
+    def select_value(sql)
+      ActiveRecord::Base.connection.select_value(sql)
+    end
+  end
+end

--- a/spec/support/function_loader_helpers.rb
+++ b/spec/support/function_loader_helpers.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ArfiSpec
+  module FunctionLoaderHelpers
+    def load_functions!
+      Arfi::SqlFunctionLoader.load!(verbose: false)
+    end
+
+    def expect_index_creation_to_succeed
+      expect do
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          CREATE INDEX idx_users_norm_email ON users (normalize_email(email));
+        SQL
+      end.not_to raise_error
+    end
+
+    def db_config(**extra)
+      { 'adapter' => 'postgresql', 'url' => ENV.fetch('ARFI_POSTGRES_URL') }.merge(extra)
+    end
+
+    def with_db_configs(configs, &block)
+      old = ActiveRecord::Base.configurations
+      ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new(configs)
+      yield
+    ensure
+      ActiveRecord::Base.configurations = old
+    end
+  end
+end

--- a/spec/support/rake_task_helpers.rb
+++ b/spec/support/rake_task_helpers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ArfiSpec
+  module RakeTaskHelpers
+    def define_tasks(*names)
+      names.each { |n| Rake::Task.define_task(n) }
+    end
+
+    def load_arfi_tasks
+      load File.expand_path('../../lib/arfi/tasks/db.rake', __dir__)
+    end
+  end
+end

--- a/spec/support/tmp_root.rb
+++ b/spec/support/tmp_root.rb
@@ -6,6 +6,15 @@ require 'tmpdir'
 
 module ArfiSpec
   module TmpRoot
+    SUBDIRS = %w[
+      db/functions/public
+      db/functions/postgresql/public
+      db/functions/mysql/public
+      db/triggers/public
+      db/triggers/postgresql/public
+      db/triggers/mysql/public
+    ].freeze
+
     def self.included(mod)
       mod.let(:root) { build_tmp_root }
       mod.before { allow(Rails).to receive_messages(root: root, env: ActiveSupport::StringInquirer.new('test')) }
@@ -14,9 +23,7 @@ module ArfiSpec
 
     def build_tmp_root
       dir = Dir.mktmpdir('arfi-spec-')
-      %w[db/functions/public db/functions/postgresql/public db/functions/mysql/public].each do |sub|
-        FileUtils.mkdir_p(Pathname.new(dir).join(sub))
-      end
+      SUBDIRS.each { |s| FileUtils.mkdir_p(Pathname.new(dir).join(s)) }
       Pathname.new(dir)
     end
 

--- a/spec/support/trigger_loader_helpers.rb
+++ b/spec/support/trigger_loader_helpers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ArfiSpec
+  module TriggerLoaderHelpers
+    def load_triggers!
+      Arfi::SqlTriggerLoader.load!(verbose: false)
+    end
+
+    def trigger_sql(name)
+      <<~SQL
+        CREATE TRIGGER #{name}
+          BEFORE INSERT ON users
+          FOR EACH ROW
+          EXECUTE FUNCTION public.arfi_before_insert();
+      SQL
+    end
+
+    def mysql_trigger_sql(name)
+      <<~SQL
+        CREATE TRIGGER #{name}
+          BEFORE INSERT ON users
+          FOR EACH ROW
+          SET NEW.name = 'triggered';
+      SQL
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds full trigger management to ARFI

### What's included

- **`arfi triggers create`** — generates SQL trigger files with skeletons for PostgreSQL (`CREATE TRIGGER … EXECUTE FUNCTION`) and MySQL/Trilogy (`CREATE TRIGGER … BEGIN … END`). Supports `--table`, `--event`, `--timing`, `--for-each`, `--function`, `--schema`, `--template`, and `--adapter`.
- **`arfi triggers destroy`** — deletes trigger files, searching legacy and new locations.
- **`arfi triggers list`** — introspects `db/triggers` and shows which files would be loaded, with `--all` to see shadowed candidates.
- **`SqlTriggerLoader`** — mirrors `SqlFunctionLoader` for `db/triggers` paths. Supports multi-DB setups and all three adapters (PostgreSQL, MySQL, Trilogy).
- **Rake hooks** — triggers are loaded during `db:prepare`, `db:migrate`, `db:test:prepare` alongside functions.
- **Runtime recovery** — `PG::UndefinedObject` errors in production now auto-reload triggers (extended from the existing function recovery).
- **Full RBS types** for all new modules and classes.
- **Comprehensive specs** — trigger loader (single DB, multi-DB, MySQL), trigger loader Rake integration, and shared spec support refactored out.

### Files changed

- **+6 new trigger modules** under `lib/arfi/commands/triggers_*.rb`
- **+1 `SqlTriggerLoader`** at `lib/arfi/sql_trigger_loader.rb`
- **+6 RBS files** under `sig/`
- **+3 new spec files** for trigger loading
- **Refactored** spec support into shared helpers (`db_helpers.rb`, `function_loader_helpers.rb`, `rake_task_helpers.rb`, `trigger_loader_helpers.rb`)
- **Minor** spec cleanup (removed unused stubs, fixed assertions)

## Checklist

- [x] Tests pass (`bundle exec rspec`)
- [x] Linter passes (`bundle exec rubocop`)
- [x] Type checker passes (`bundle exec steep check`)
- [x] Docs are up to date (`bundle exec docscribe lib spec --rbs-collection`)
- [x] Commit messages follow conventional commits