### PR TITLE
[1.1.0] Add functions `validate`/`doctor` CLI commands

### DIFF
--- a/lib/arfi/commands/functions.rb
+++ b/lib/arfi/commands/functions.rb
@@ -10,6 +10,7 @@ require_relative 'functions_creation'
 require_relative 'functions_paths'
 require_relative 'functions_rendering'
 require_relative 'functions_candidates'
+require_relative 'functions_doctor'
 
 module Arfi
   module Commands
@@ -25,6 +26,7 @@ module Arfi
       include FunctionsPaths
       include FunctionsRendering
       include FunctionsCandidates
+      include FunctionsDoctor
 
       default_task :list
 
@@ -122,6 +124,48 @@ module Arfi
         rows = resolve_functions_for(adapter: adapter)
 
         render_list(rows)
+      end
+
+      # steep:ignore:start
+      desc(
+        'validate [--adapter=adapter] [--format=table|paths|json]',
+        "Validate SQL function files by running them against the database.\n" \
+        "On PostgreSQL, runs inside a transaction that is rolled back.\n" \
+        'On MySQL/Trilogy, functions are loaded as a side effect.'
+      )
+      option :adapter, type: :string,
+                       desc: "Specify database adapter. Available adapters: #{ADAPTERS.join(', ')}",
+                       banner: 'adapter'
+      option :format, type: :string, default: 'table',
+                      desc: 'Output format: table, paths, json'
+      # steep:ignore:end
+      # Validate all SQL function files by executing them against the database.
+      #
+      # On PostgreSQL, each file runs inside a transaction that is rolled back.
+      # On MySQL/Trilogy, DDL auto-commits, so functions are loaded as a side effect.
+      #
+      # @return [void]
+      def validate
+        super
+      end
+
+      # steep:ignore:start
+      desc(
+        'doctor [--adapter=adapter] [--format=table|paths|json]',
+        "Check function status: compare files on disk vs the database.\n" \
+        'Shows each resolved function as OK (exists) or MISSING (not in DB).'
+      )
+      option :adapter, type: :string,
+                       desc: "Specify database adapter. Available adapters: #{ADAPTERS.join(', ')}",
+                       banner: 'adapter'
+      option :format, type: :string, default: 'table',
+                      desc: 'Output format: table, paths, json'
+      # steep:ignore:end
+      # Compare functions on disk vs the database and report discrepancies.
+      #
+      # @return [void]
+      def doctor
+        super
       end
     end
   end

--- a/lib/arfi/commands/functions.rb
+++ b/lib/arfi/commands/functions.rb
@@ -145,9 +145,6 @@ module Arfi
       # On MySQL/Trilogy, DDL auto-commits, so functions are loaded as a side effect.
       #
       # @return [void]
-      def validate
-        super
-      end
 
       # steep:ignore:start
       desc(
@@ -164,9 +161,6 @@ module Arfi
       # Compare functions on disk vs the database and report discrepancies.
       #
       # @return [void]
-      def doctor
-        super
-      end
     end
   end
 end

--- a/lib/arfi/commands/functions.rb
+++ b/lib/arfi/commands/functions.rb
@@ -10,6 +10,7 @@ require_relative 'functions_creation'
 require_relative 'functions_paths'
 require_relative 'functions_rendering'
 require_relative 'functions_candidates'
+require_relative 'functions_doctor_rendering'
 require_relative 'functions_doctor'
 
 module Arfi
@@ -145,6 +146,9 @@ module Arfi
       # On MySQL/Trilogy, DDL auto-commits, so functions are loaded as a side effect.
       #
       # @return [void]
+      def validate # rubocop:disable Lint/UselessMethodDefinition
+        super
+      end
 
       # steep:ignore:start
       desc(
@@ -161,6 +165,9 @@ module Arfi
       # Compare functions on disk vs the database and report discrepancies.
       #
       # @return [void]
+      def doctor # rubocop:disable Lint/UselessMethodDefinition
+        super
+      end
     end
   end
 end

--- a/lib/arfi/commands/functions_doctor.rb
+++ b/lib/arfi/commands/functions_doctor.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+module Arfi
+  module Commands
+    # Validation and doctor helpers for {Arfi::Commands::Functions}.
+    module FunctionsDoctor
+      private
+
+      # Validate all SQL function files by trying to execute them against a database connection.
+      #
+      # On PostgreSQL, each file is validated inside a transaction that is rolled back,
+      # leaving the database state unchanged. On MySQL/Trilogy, DDL auto-commits,
+      # so the functions will be loaded as a side effect of validation.
+      #
+      # @return [void]
+      def validate
+        validate_schema_format!
+        validate_adapter_option!
+
+        adapter = resolve_adapter
+        conn = establish_connection
+
+        raise_unless_supported_adapter(conn)
+
+        files = discover_function_files(conn)
+        if files.empty?
+          puts 'No SQL function files found.'
+          return
+        end
+
+        results = files.map { |file| validate_sql_file(conn, file) }
+        report_validate_results(results)
+      end
+
+      # Compare functions on disk vs the database and report discrepancies.
+      #
+      # Shows each resolved function (highest-priority candidate per key) with its status:
+      # - OK: function exists in the database
+      # - MISSING: function file exists on disk but is not in the database
+      #
+      # @return [void]
+      def doctor
+        validate_schema_format!
+        validate_adapter_option!
+
+        adapter = resolve_adapter
+        conn = establish_connection
+
+        raise_unless_supported_adapter(conn)
+
+        root = Rails.root.join(ROOT_DIR)
+        raise Arfi::Errors::NoFunctionsDir unless root.directory?
+
+        candidates = collect_all_candidates(root, adapter)
+        by_key = group_candidates_by_key(candidates)
+        resolved = build_resolved_rows(by_key)
+
+        results = resolved.map { |row| doctor_check_function(conn, row) }
+        report_doctor_results(results)
+      end
+
+      private
+
+      # Establish a database connection for validation/doctor operations.
+      #
+      # @private
+      # @return [ActiveRecord::ConnectionAdapters::AbstractAdapter]
+      def establish_connection
+        if Rails::VERSION::MAJOR < 7 || (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR < 2)
+          ActiveRecord::Base.connection
+        else
+          ActiveRecord::Base.lease_connection
+        end
+      end
+
+      # Raise unless the connection adapter is PostgreSQL, Mysql2, or Trilogy.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @raise [Arfi::Errors::AdapterNotSupported]
+      # @return [void]
+      def raise_unless_supported_adapter(conn)
+        allowed = %w[
+          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+          ActiveRecord::ConnectionAdapters::Mysql2Adapter
+          ActiveRecord::ConnectionAdapters::TrilogyAdapter
+        ].freeze
+
+        raise Arfi::Errors::AdapterNotSupported unless allowed.include?(conn.class.name)
+      end
+
+      # Check whether the connection is PostgreSQL.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @return [Boolean]
+      def postgresql_adapter?(conn)
+        conn.class.name == 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
+      end
+
+      # Discover the effective set of SQL function files for the given connection.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @return [Array<String>] list of file paths
+      def discover_function_files(conn)
+        Arfi::SqlFunctionLoader.send(:sql_files, conn)
+      end
+
+      # Validate a single SQL file by executing it against the database.
+      #
+      # On PostgreSQL, wraps execution in a transaction with rollback to avoid side effects.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [String] file path to the SQL file
+      # @return [Hash] result with :file, :status, and optionally :error keys
+      def validate_sql_file(conn, file)
+        sql = File.read(file.to_s).strip
+        return { file: file, status: 'SKIP', error: 'File is empty' } if sql.empty?
+
+        if postgresql_adapter?(conn)
+          conn.transaction do
+            conn.execute(sql)
+            raise ActiveRecord::Rollback
+          end
+        else
+          conn.execute(sql)
+        end
+
+        { file: file, status: 'OK' }
+      rescue StandardError => e
+        { file: file, status: 'FAIL', error: e.message }
+      end
+
+      # Check whether a resolved function exists in the database.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [Hash<Symbol, Object>] row resolved function row from candidates
+      # @return [Hash] result with :function, :schema, :status, :path keys
+      def doctor_check_function(_conn, row)
+        function_name = row[:function]
+        schema = row[:schema]
+        path = row[:path]
+
+        exists = ActiveRecord::Base.function_exists?(function_name)
+
+        { function: function_name, schema: schema, status: exists ? 'OK' : 'MISSING', path: path }
+      end
+
+      # Render validation results in the selected output format.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def report_validate_results(results)
+        case options[:format].to_s
+        when 'json'
+          puts JSON.pretty_generate(results.map { |r| format_validate_result(r) })
+        when 'paths'
+          results.each { |r| puts "#{rel(r[:file])}  #{r[:status]}" }
+        else
+          print_validate_table(results)
+        end
+      end
+
+      # Format a validation result for JSON output.
+      #
+      # @private
+      # @param [Hash] r
+      # @return [Hash]
+      def format_validate_result(r)
+        { file: rel(r[:file]), status: r[:status], error: r[:error] }.compact
+      end
+
+      # Print validation results as an ASCII table.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def print_validate_table(results)
+        cols = %w[file status error]
+        rows = results.map do |r|
+          { file: rel(r[:file]), status: r[:status], error: r[:error] || '' }
+        end
+        widths = calculate_col_widths(cols, rows)
+        print_separator(cols, widths)
+        rows.each do |r|
+          puts cols.map { |c| r[c.to_sym].to_s.ljust(widths[c]) }.join('  ')
+        end
+      end
+
+      # Render doctor results in the selected output format.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def report_doctor_results(results)
+        case options[:format].to_s
+        when 'json'
+          puts JSON.pretty_generate(results)
+        when 'paths'
+          results.each { |r| puts "#{rel(r[:path])}  #{r[:status]}" }
+        else
+          print_doctor_table(results)
+        end
+      end
+
+      # Print doctor results as an ASCII table.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def print_doctor_table(results)
+        cols = %w[function schema status path]
+        rows = results.map do |r|
+          { function: r[:function], schema: r[:schema], status: r[:status], path: rel(r[:path]) }
+        end
+        widths = calculate_col_widths(cols, rows)
+        print_separator(cols, widths)
+        rows.each do |r|
+          puts cols.map { |c| r[c.to_sym].to_s.ljust(widths[c]) }.join('  ')
+        end
+      end
+
+      # Calculate column widths for a table.
+      #
+      # @private
+      # @param [Array<String>] cols column names
+      # @param [Array<Hash>] rows
+      # @return [Hash<String, Integer>]
+      def calculate_col_widths(cols, rows)
+        widths = {}
+        cols.each do |c|
+          widths[c] = ([c.length] + rows.map { |r| r[c.to_sym].to_s.length }).max
+        end
+        widths
+      end
+
+      # Print table header and separator line.
+      #
+      # @private
+      # @param [Array<String>] cols
+      # @param [Hash<String, Integer>] widths
+      # @return [void]
+      def print_separator(cols, widths)
+        puts cols.map { |c| c.ljust(widths[c]) }.join('  ')
+        puts cols.map { |c| '-' * widths[c] }.join('  ')
+      end
+    end
+  end
+end

--- a/lib/arfi/commands/functions_doctor.rb
+++ b/lib/arfi/commands/functions_doctor.rb
@@ -4,6 +4,8 @@ module Arfi
   module Commands
     # Validation and doctor helpers for {Arfi::Commands::Functions}.
     module FunctionsDoctor
+      include FunctionsDoctorRendering
+
       private
 
       # Validate all SQL function files by trying to execute them against a database connection.
@@ -12,15 +14,10 @@ module Arfi
       # leaving the database state unchanged. On MySQL/Trilogy, DDL auto-commits,
       # so the functions will be loaded as a side effect of validation.
       #
+      # @private
       # @return [void]
       def validate
-        validate_schema_format!
-        validate_adapter_option!
-
-        resolve_adapter
-        conn = establish_connection
-
-        raise_unless_supported_adapter(conn)
+        conn = prepare_connection
 
         files = discover_function_files(conn)
         if files.empty?
@@ -38,25 +35,40 @@ module Arfi
       # - OK: function exists in the database
       # - MISSING: function file exists on disk but is not in the database
       #
+      # @private
       # @return [void]
       def doctor
+        conn = prepare_connection
+        resolved = resolve_candidates
+        results = resolved.map { |row| doctor_check_function(conn, row) }
+        report_doctor_results(results)
+      end
+
+      # Run shared setup steps for validate/doctor commands.
+      #
+      # @private
+      # @return [ActiveRecord::ConnectionAdapters::AbstractAdapter]
+      def prepare_connection
         validate_schema_format!
         validate_adapter_option!
-
-        adapter = resolve_adapter
         conn = establish_connection
-
         raise_unless_supported_adapter(conn)
+        conn
+      end
 
+      # Resolve function candidates from disk for doctor.
+      #
+      # @private
+      # @raise [Arfi::Errors::NoFunctionsDir]
+      # @return [Array<Hash{Symbol => Object}>]
+      def resolve_candidates
         root = Rails.root.join(ROOT_DIR)
         raise Arfi::Errors::NoFunctionsDir unless root.directory?
 
+        adapter = resolve_adapter
         candidates = collect_all_candidates(root, adapter)
         by_key = group_candidates_by_key(candidates)
-        resolved = build_resolved_rows(by_key)
-
-        results = resolved.map { |row| doctor_check_function(conn, row) }
-        report_doctor_results(results)
+        build_resolved_rows(by_key)
       end
 
       # Establish a database connection for validation/doctor operations.
@@ -103,11 +115,26 @@ module Arfi
       # @private
       # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
       # @param [String] file path to the SQL file
+      # @raise [StandardError]
       # @return [Hash] result with :file, :status, and optionally :error keys
       def validate_sql_file(conn, file)
         sql = File.read(file.to_s).strip
         return { file: file, status: 'SKIP', error: 'File is empty' } if sql.empty?
 
+        execute_sql_safely(conn, sql)
+        { file: file, status: 'OK' }
+      rescue StandardError => e
+        { file: file, status: 'FAIL', error: e.message }
+      end
+
+      # Execute SQL safely inside a rollback transaction on PostgreSQL, or directly otherwise.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [String] sql SQL to execute
+      # @raise [ActiveRecord::Rollback]
+      # @return [void]
+      def execute_sql_safely(conn, sql)
         if postgresql_adapter?(conn)
           conn.transaction do
             conn.execute(sql)
@@ -116,10 +143,6 @@ module Arfi
         else
           conn.execute(sql)
         end
-
-        { file: file, status: 'OK' }
-      rescue StandardError => e
-        { file: file, status: 'FAIL', error: e.message }
       end
 
       # Check whether the connection is PostgreSQL.
@@ -135,116 +158,16 @@ module Arfi
       #
       # @private
       # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
-      # @param [Hash<Symbol, Object>] row resolved function row from candidates
+      # @param [Hash{Symbol => Object}] row resolved function row from candidates
+      # @param [Object] _conn Param documentation.
       # @return [Hash] result with :function, :schema, :status, :path keys
       def doctor_check_function(_conn, row)
         function_name = row[:function]
         schema = row[:schema]
         path = row[:path]
-
         exists = ActiveRecord::Base.function_exists?(function_name)
 
         { function: function_name, schema: schema, status: exists ? 'OK' : 'MISSING', path: path }
-      end
-
-      # Render validation results in the selected output format.
-      #
-      # @private
-      # @param [Array<Hash>] results
-      # @return [void]
-      def report_validate_results(results)
-        case options[:format].to_s
-        when 'json'
-          puts JSON.pretty_generate(results.map { |r| format_validate_result(r) })
-        when 'paths'
-          results.each { |r| puts "#{rel(r[:file])}  #{r[:status]}" }
-        else
-          print_validate_table(results)
-        end
-      end
-
-      # Format a validation result for JSON output.
-      #
-      # @private
-      # @param [Hash] r
-      # @return [Hash]
-      def format_validate_result(r)
-        { file: rel(r[:file]), status: r[:status], error: r[:error] }.compact
-      end
-
-      # Print validation results as an ASCII table.
-      #
-      # @private
-      # @param [Array<Hash>] results
-      # @return [void]
-      def print_validate_table(results)
-        cols = %w[file status error]
-        rows = results.map do |r|
-          { file: rel(r[:file]), status: r[:status], error: r[:error] || '' }
-        end
-        widths = calculate_col_widths(cols, rows)
-        print_separator(cols, widths)
-        rows.each do |r|
-          puts cols.map { |c| r[c.to_sym].to_s.ljust(widths[c]) }.join('  ')
-        end
-      end
-
-      # Render doctor results in the selected output format.
-      #
-      # @private
-      # @param [Array<Hash>] results
-      # @return [void]
-      def report_doctor_results(results)
-        case options[:format].to_s
-        when 'json'
-          puts JSON.pretty_generate(results)
-        when 'paths'
-          results.each { |r| puts "#{rel(r[:path])}  #{r[:status]}" }
-        else
-          print_doctor_table(results)
-        end
-      end
-
-      # Print doctor results as an ASCII table.
-      #
-      # @private
-      # @param [Array<Hash>] results
-      # @return [void]
-      def print_doctor_table(results)
-        cols = %w[function schema status path]
-        rows = results.map do |r|
-          { function: r[:function], schema: r[:schema], status: r[:status], path: rel(r[:path]) }
-        end
-        widths = calculate_col_widths(cols, rows)
-        print_separator(cols, widths)
-        rows.each do |r|
-          puts cols.map { |c| r[c.to_sym].to_s.ljust(widths[c]) }.join('  ')
-        end
-      end
-
-      # Calculate column widths for a table.
-      #
-      # @private
-      # @param [Array<String>] cols column names
-      # @param [Array<Hash>] rows
-      # @return [Hash<String, Integer>]
-      def calculate_col_widths(cols, rows)
-        widths = {}
-        cols.each do |c|
-          widths[c] = ([c.length] + rows.map { |r| r[c.to_sym].to_s.length }).max
-        end
-        widths
-      end
-
-      # Print table header and separator line.
-      #
-      # @private
-      # @param [Array<String>] cols
-      # @param [Hash<String, Integer>] widths
-      # @return [void]
-      def print_separator(cols, widths)
-        puts cols.map { |c| c.ljust(widths[c]) }.join('  ')
-        puts cols.map { |c| '-' * widths[c] }.join('  ')
       end
     end
   end

--- a/lib/arfi/commands/functions_doctor.rb
+++ b/lib/arfi/commands/functions_doctor.rb
@@ -17,7 +17,7 @@ module Arfi
         validate_schema_format!
         validate_adapter_option!
 
-        adapter = resolve_adapter
+        resolve_adapter
         conn = establish_connection
 
         raise_unless_supported_adapter(conn)
@@ -59,8 +59,6 @@ module Arfi
         report_doctor_results(results)
       end
 
-      private
-
       # Establish a database connection for validation/doctor operations.
       #
       # @private
@@ -87,15 +85,6 @@ module Arfi
         ].freeze
 
         raise Arfi::Errors::AdapterNotSupported unless allowed.include?(conn.class.name)
-      end
-
-      # Check whether the connection is PostgreSQL.
-      #
-      # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
-      # @return [Boolean]
-      def postgresql_adapter?(conn)
-        conn.class.name == 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
       end
 
       # Discover the effective set of SQL function files for the given connection.
@@ -131,6 +120,15 @@ module Arfi
         { file: file, status: 'OK' }
       rescue StandardError => e
         { file: file, status: 'FAIL', error: e.message }
+      end
+
+      # Check whether the connection is PostgreSQL.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @return [Boolean]
+      def postgresql_adapter?(conn)
+        conn.instance_of?(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
       end
 
       # Check whether a resolved function exists in the database.

--- a/lib/arfi/commands/functions_doctor_rendering.rb
+++ b/lib/arfi/commands/functions_doctor_rendering.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Arfi
+  module Commands
+    # Table-rendering helpers for {Arfi::Commands::FunctionsDoctor}.
+    module FunctionsDoctorRendering
+      private
+
+      # Render validation results in the selected output format.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def report_validate_results(results)
+        case options[:format].to_s
+        when 'json'
+          puts JSON.pretty_generate(results.map { |result| format_validate_result(result) })
+        when 'paths'
+          results.each { |result| puts "#{rel(result[:file].to_s)}  #{result[:status]}" }
+        else
+          print_validate_table(results)
+        end
+      end
+
+      # Format a validation result for JSON output.
+      #
+      # @private
+      # @param [Hash] result
+      # @return [Hash]
+      def format_validate_result(result)
+        { file: rel(result[:file].to_s), status: result[:status], error: result[:error] }.compact
+      end
+
+      # Print validation results as an ASCII table.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def print_validate_table(results)
+        cols = %w[file status error]
+        rows = build_validate_rows(results)
+        widths = calculate_col_widths(cols, rows)
+        print_separator(cols, widths)
+        rows.each do |row|
+          puts cols.map { |c| row[c.to_sym].to_s.ljust(widths[c]) }.join('  ')
+        end
+      end
+
+      # Build table rows for validate results.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [Array<Hash{Symbol => String}>]
+      def build_validate_rows(results)
+        results.map do |result| # steep:ignore
+          { file: rel(result[:file].to_s), status: result[:status], error: result[:error] || '' }
+        end
+      end
+
+      # Render doctor results in the selected output format.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def report_doctor_results(results)
+        case options[:format].to_s
+        when 'json'
+          puts JSON.pretty_generate(results)
+        when 'paths'
+          results.each { |result| puts "#{rel(result[:path].to_s)}  #{result[:status]}" }
+        else
+          print_doctor_table(results)
+        end
+      end
+
+      # Print doctor results as an ASCII table.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def print_doctor_table(results)
+        cols = %w[function schema status path]
+        rows = build_doctor_rows(results)
+        widths = calculate_col_widths(cols, rows)
+        print_separator(cols, widths)
+        rows.each do |row|
+          puts cols.map { |c| row[c.to_sym].to_s.ljust(widths[c]) }.join('  ')
+        end
+      end
+
+      # Build table rows for doctor results.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [Array<Hash{Symbol => String}>]
+      def build_doctor_rows(results)
+        results.map do |result|
+          { function: result[:function], schema: result[:schema], status: result[:status],
+            path: rel(result[:path].to_s) }
+        end
+      end
+
+      # Calculate column widths for a table.
+      #
+      # @private
+      # @param [Array<String>] cols column names
+      # @param [Array<Hash>] rows
+      # @return [Hash<String, Integer>]
+      def calculate_col_widths(cols, rows)
+        widths = {} # steep:ignore
+        cols.each do |c|
+          widths[c] = ([c.length] + rows.map { |r| r[c.to_sym].to_s.length }).max
+        end
+        widths
+      end
+
+      # Print table header and separator line.
+      #
+      # @private
+      # @param [Array<String>] cols
+      # @param [Hash<String, Integer>] widths
+      # @return [void]
+      def print_separator(cols, widths)
+        puts cols.map { |c| c.ljust(widths[c]) }.join('  ')
+        puts cols.map { |c| '-' * widths[c] }.join('  ')
+      end
+    end
+  end
+end

--- a/lib/arfi/version.rb
+++ b/lib/arfi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Arfi
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/sig/lib/arfi/commands/functions.rbs
+++ b/sig/lib/arfi/commands/functions.rbs
@@ -41,6 +41,12 @@ module Arfi
       # steep:ignore:end
       def list: () -> void
 
+      # steep:ignore:end
+      def validate: () -> void
+
+      # steep:ignore:end
+      def doctor: () -> void
+
       private
 
       def validate_schema_format!: () -> void

--- a/sig/lib/arfi/commands/functions_doctor.rbs
+++ b/sig/lib/arfi/commands/functions_doctor.rbs
@@ -1,7 +1,17 @@
 module Arfi
   module Commands
     module FunctionsDoctor : Arfi::Commands::Functions
+      include FunctionsDoctorRendering
+
       private
+
+      def validate: () -> void
+
+      def doctor: () -> void
+
+      def prepare_connection: () -> ::ActiveRecord::ConnectionAdapters::AbstractAdapter
+
+      def resolve_candidates: () -> Array[::Hash[Symbol, untyped]]
 
       def establish_connection: () -> ::ActiveRecord::ConnectionAdapters::AbstractAdapter
 
@@ -9,25 +19,13 @@ module Arfi
 
       def postgresql_adapter?: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> bool
 
+      def execute_sql_safely: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, String sql) -> void
+
       def discover_function_files: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> Array[String]
 
       def validate_sql_file: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, String file) -> ::Hash[Symbol, String?]
 
       def doctor_check_function: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, ::Hash[Symbol, untyped] row) -> ::Hash[Symbol, String]
-
-      def report_validate_results: (Array[::Hash[Symbol, String?]] results) -> void
-
-      def format_validate_result: (::Hash[Symbol, String?] r) -> ::Hash[Symbol, String?]
-
-      def print_validate_table: (Array[::Hash[Symbol, String?]] results) -> void
-
-      def report_doctor_results: (Array[::Hash[Symbol, String]] results) -> void
-
-      def print_doctor_table: (Array[::Hash[Symbol, String]] results) -> void
-
-      def calculate_col_widths: (Array[String] cols, Array[::Hash[Symbol, String]] rows) -> ::Hash[String, Integer]
-
-      def print_separator: (Array[String] cols, ::Hash[String, Integer] widths) -> void
     end
   end
 end

--- a/sig/lib/arfi/commands/functions_doctor.rbs
+++ b/sig/lib/arfi/commands/functions_doctor.rbs
@@ -1,0 +1,33 @@
+module Arfi
+  module Commands
+    module FunctionsDoctor : Arfi::Commands::Functions
+      private
+
+      def establish_connection: () -> ::ActiveRecord::ConnectionAdapters::AbstractAdapter
+
+      def raise_unless_supported_adapter: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> void
+
+      def postgresql_adapter?: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> bool
+
+      def discover_function_files: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> Array[String]
+
+      def validate_sql_file: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, String file) -> ::Hash[Symbol, String?]
+
+      def doctor_check_function: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, ::Hash[Symbol, untyped] row) -> ::Hash[Symbol, String]
+
+      def report_validate_results: (Array[::Hash[Symbol, String?]] results) -> void
+
+      def format_validate_result: (::Hash[Symbol, String?] r) -> ::Hash[Symbol, String?]
+
+      def print_validate_table: (Array[::Hash[Symbol, String?]] results) -> void
+
+      def report_doctor_results: (Array[::Hash[Symbol, String]] results) -> void
+
+      def print_doctor_table: (Array[::Hash[Symbol, String]] results) -> void
+
+      def calculate_col_widths: (Array[String] cols, Array[::Hash[Symbol, String]] rows) -> ::Hash[String, Integer]
+
+      def print_separator: (Array[String] cols, ::Hash[String, Integer] widths) -> void
+    end
+  end
+end

--- a/sig/lib/arfi/commands/functions_doctor_rendering.rbs
+++ b/sig/lib/arfi/commands/functions_doctor_rendering.rbs
@@ -1,0 +1,25 @@
+module Arfi
+  module Commands
+    module FunctionsDoctorRendering : Arfi::Commands::Functions
+      private
+
+      def report_validate_results: (Array[::Hash[Symbol, String?]] results) -> void
+
+      def format_validate_result: (::Hash[Symbol, String?] result) -> ::Hash[Symbol, String]
+
+      def build_validate_rows: (Array[::Hash[Symbol, String?]] results) -> Array[::Hash[Symbol, String]]
+
+      def print_validate_table: (Array[::Hash[Symbol, String?]] results) -> void
+
+      def report_doctor_results: (Array[::Hash[Symbol, String]] results) -> void
+
+      def build_doctor_rows: (Array[::Hash[Symbol, String]] results) -> Array[::Hash[Symbol, String]]
+
+      def print_doctor_table: (Array[::Hash[Symbol, String]] results) -> void
+
+      def calculate_col_widths: (Array[String] cols, Array[::Hash[Symbol, String]] rows) -> ::Hash[String, Integer]
+
+      def print_separator: (Array[String] cols, ::Hash[String, Integer] widths) -> void
+    end
+  end
+end

--- a/spec/arfi/commands/functions_doctor_spec.rb
+++ b/spec/arfi/commands/functions_doctor_spec.rb
@@ -55,14 +55,9 @@ RSpec.describe Arfi::Commands::Functions do
 
   describe 'doctor' do
     it 'reports OK for functions that exist in the database', :pgsql do
-      write_function('db/functions/public/existing_fn.sql', <<~SQL)
-        CREATE OR REPLACE FUNCTION existing_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
-      SQL
-
-      ActiveRecord::Base.connection.execute(<<~SQL)
-        CREATE OR REPLACE FUNCTION existing_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
-      SQL
-
+      fn = 'CREATE OR REPLACE FUNCTION existing_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;'
+      write_function('db/functions/public/existing_fn.sql', fn)
+      ActiveRecord::Base.connection.execute(fn)
       expect { described_class.start(%w[doctor --adapter=postgresql --format=paths]) }
         .to output(/OK/).to_stdout
     end

--- a/spec/arfi/commands/functions_doctor_spec.rb
+++ b/spec/arfi/commands/functions_doctor_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Arfi::Commands::Functions do
+  include ArfiSpec::TmpRoot
+
+  describe 'validate' do
+    it 'reports OK for a valid SQL function file', :pgsql do
+      write_function('db/functions/public/valid_fn.sql', <<~SQL)
+        CREATE OR REPLACE FUNCTION valid_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+      SQL
+
+      expect { described_class.start(%w[validate --adapter=postgresql --format=paths]) }
+        .to output(/OK/).to_stdout
+    end
+
+    it 'reports FAIL for invalid SQL syntax', :pgsql do
+      write_function('db/functions/public/bad_fn.sql', <<~SQL)
+        CREATE OR REPLACE FUNCTION bad_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT syntax_error; $$;
+      SQL
+
+      expect { described_class.start(%w[validate --adapter=postgresql --format=paths]) }
+        .to output(/FAIL/).to_stdout
+    end
+
+    it 'does not leave functions in the database after validation on PostgreSQL', :pgsql do
+      write_function('db/functions/public/transient_fn.sql', <<~SQL)
+        CREATE OR REPLACE FUNCTION transient_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+      SQL
+
+      described_class.start(%w[validate --adapter=postgresql --format=paths])
+
+      expect(ActiveRecord::Base.function_exists?('transient_fn')).to be false
+    end
+
+    it 'reports OK via table format by default', :pgsql do
+      write_function('db/functions/public/table_fn.sql', <<~SQL)
+        CREATE OR REPLACE FUNCTION table_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+      SQL
+
+      expect { described_class.start(%w[validate --adapter=postgresql]) }
+        .to output(/table_fn.+OK/).to_stdout
+    end
+
+    it 'outputs valid JSON with --format=json', :pgsql do
+      write_function('db/functions/public/json_fn.sql', <<~SQL)
+        CREATE OR REPLACE FUNCTION json_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+      SQL
+
+      expect { described_class.start(%w[validate --adapter=postgresql --format=json]) }
+        .to output(/"status":\s*"OK"/).to_stdout
+    end
+  end
+
+  describe 'doctor' do
+    it 'reports OK for functions that exist in the database', :pgsql do
+      write_function('db/functions/public/existing_fn.sql', <<~SQL)
+        CREATE OR REPLACE FUNCTION existing_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+      SQL
+
+      ActiveRecord::Base.connection.execute(<<~SQL)
+        CREATE OR REPLACE FUNCTION existing_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+      SQL
+
+      expect { described_class.start(%w[doctor --adapter=postgresql --format=paths]) }
+        .to output(/OK/).to_stdout
+    end
+
+    it 'reports MISSING for functions not in the database', :pgsql do
+      write_function('db/functions/public/missing_fn.sql', <<~SQL)
+        CREATE OR REPLACE FUNCTION missing_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+      SQL
+
+      expect { described_class.start(%w[doctor --adapter=postgresql --format=paths]) }
+        .to output(/MISSING/).to_stdout
+    end
+
+    it 'outputs valid JSON with --format=json', :pgsql do
+      write_function('db/functions/public/json_doc_fn.sql', <<~SQL)
+        CREATE OR REPLACE FUNCTION json_doc_fn() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+      SQL
+
+      expect { described_class.start(%w[doctor --adapter=postgresql --format=json]) }
+        .to output(/"status":\s*"MISSING"/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add `arfi functions validate` and `arfi functions doctor` CLI commands for validating SQL function files and checking function status against the database.

- **`validate`** — runs each SQL function file against the database (PostgreSQL: inside ROLLBACK transaction; MySQL/Trilogy: executed directly, loaded as side effect)
- **`doctor`** — compares resolved function candidates on disk against the database, reports OK or MISSING per function

Refactored `FunctionsDoctor` module: extracted rendering helpers into `FunctionsDoctorRendering`, added `prepare_connection`/`resolve_candidates`/`execute_sql_safely` helpers for cleaner method sizes. Thor command registration via proxy methods in `Functions` class.

## Checklist

- [x] Tests pass (`bundle exec rspec`)
- [x] Linter passes (`bundle exec rubocop`)
- [x] Type checker passes (`bundle exec steep check`)
- [x] Docs are up to date (`bundle exec docscribe lib spec --rbs-collection`)
- [x] Commit messages follow conventional commits