### PR TITLE
[1.1.0] Add triggers validate/doctor CLI commands

### DIFF
--- a/lib/arfi/commands/triggers.rb
+++ b/lib/arfi/commands/triggers.rb
@@ -10,6 +10,8 @@ require_relative 'triggers_creation'
 require_relative 'triggers_paths'
 require_relative 'triggers_rendering'
 require_relative 'triggers_candidates'
+require_relative 'triggers_doctor_rendering'
+require_relative 'triggers_doctor'
 
 module Arfi
   module Commands
@@ -22,6 +24,7 @@ module Arfi
       include TriggersPaths
       include TriggersRendering
       include TriggersCandidates
+      include TriggersDoctor
 
       default_task :list
 
@@ -137,6 +140,51 @@ module Arfi
         rows = resolve_triggers_for(adapter: adapter)
 
         render_list(rows)
+      end
+
+      # steep:ignore:start
+      desc(
+        'validate [--adapter=adapter] [--format=table|paths|json]',
+        "Validate SQL trigger files by running them against the database.\n" \
+        "On PostgreSQL, runs inside a transaction that is rolled back.\n" \
+        'On MySQL/Trilogy, triggers are loaded as a side effect.'
+      )
+      option :adapter, type: :string,
+                       desc: "Specify database adapter. Available adapters: #{ADAPTERS.join(', ')}",
+                       banner: 'adapter'
+      option :format, type: :string, default: 'table',
+                      desc: 'Output format: table, paths, json'
+      # steep:ignore:end
+      # Validate all SQL trigger files by executing them against the database.
+      #
+      # Delegates to {TriggersDoctor#validate}. On PostgreSQL, each file runs
+      # inside a transaction that is rolled back. On MySQL/Trilogy, DDL commits.
+      #
+      # @return [void]
+      def validate # rubocop:disable Lint/UselessMethodDefinition
+        super
+      end
+
+      # steep:ignore:start
+      desc(
+        'doctor [--adapter=adapter] [--format=table|paths|json]',
+        "Check trigger status: compare files on disk vs the database.\n" \
+        'Shows each resolved trigger as OK (exists) or MISSING (not in DB).'
+      )
+      option :adapter, type: :string,
+                       desc: "Specify database adapter. Available adapters: #{ADAPTERS.join(', ')}",
+                       banner: 'adapter'
+      option :format, type: :string, default: 'table',
+                      desc: 'Output format: table, paths, json'
+      # steep:ignore:end
+      # Compare trigger files on disk vs the database and report discrepancies.
+      #
+      # Delegates to {TriggersDoctor#doctor}. Shows each resolved trigger as OK
+      # (exists in DB) or MISSING (file on disk but not loaded).
+      #
+      # @return [void]
+      def doctor # rubocop:disable Lint/UselessMethodDefinition
+        super
       end
     end
   end

--- a/lib/arfi/commands/triggers_doctor.rb
+++ b/lib/arfi/commands/triggers_doctor.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+module Arfi
+  module Commands
+    # Validation and doctor helpers for {Arfi::Commands::Triggers}.
+    module TriggersDoctor
+      include TriggersDoctorRendering
+
+      private
+
+      # Validate all SQL trigger files by executing them against the database.
+      #
+      # On PostgreSQL, each file is validated inside a transaction that is rolled back,
+      # leaving the database state unchanged. On MySQL/Trilogy, DDL auto-commits,
+      # so triggers will be loaded as a side effect of validation.
+      #
+      # @private
+      # @return [void]
+      def validate
+        conn = prepare_connection
+
+        files = discover_trigger_files(conn)
+        if files.empty?
+          puts 'No SQL trigger files found.'
+          return
+        end
+
+        results = files.map { |file| validate_sql_file(conn, file) }
+        report_validate_results(results)
+      end
+
+      # Compare trigger files on disk vs the database and report discrepancies.
+      #
+      # Shows each resolved trigger (highest-priority candidate per key) with its status:
+      # - OK: trigger exists in the database
+      # - MISSING: trigger file exists on disk but is not in the database
+      #
+      # @private
+      # @return [void]
+      def doctor
+        conn = prepare_connection
+        resolved = resolve_candidates
+        results = resolved.map { |row| doctor_check_trigger(conn, row) }
+        report_doctor_results(results)
+      end
+
+      # Run shared setup steps for validate/doctor commands.
+      #
+      # @private
+      # @return [ActiveRecord::ConnectionAdapters::AbstractAdapter]
+      def prepare_connection
+        validate_schema_format!
+        validate_adapter_option!
+        conn = establish_connection
+        raise_unless_supported_adapter(conn)
+        conn
+      end
+
+      # Resolve trigger candidates from disk for doctor.
+      #
+      # @private
+      # @raise [Arfi::Errors::NoTriggersDir]
+      # @return [Array<Hash{Symbol => Object}>]
+      def resolve_candidates
+        root = Rails.root.join(TRIGGERS_ROOT_DIR)
+        raise Arfi::Errors::NoTriggersDir unless root.directory?
+
+        adapter = resolve_adapter
+        candidates = collect_all_candidates(root, adapter)
+        by_key = group_candidates_by_key(candidates)
+        build_resolved_rows(by_key)
+      end
+
+      # Establish a database connection for validation/doctor operations.
+      #
+      # @private
+      # @return [ActiveRecord::ConnectionAdapters::AbstractAdapter]
+      def establish_connection
+        if Rails::VERSION::MAJOR < 7 || (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR < 2)
+          ActiveRecord::Base.connection
+        else
+          ActiveRecord::Base.lease_connection
+        end
+      end
+
+      # Raise unless the connection adapter is PostgreSQL, Mysql2, or Trilogy.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @raise [Arfi::Errors::AdapterNotSupported]
+      # @return [void]
+      def raise_unless_supported_adapter(conn)
+        allowed = %w[
+          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+          ActiveRecord::ConnectionAdapters::Mysql2Adapter
+          ActiveRecord::ConnectionAdapters::TrilogyAdapter
+        ].freeze
+
+        raise Arfi::Errors::AdapterNotSupported unless allowed.include?(conn.class.name)
+      end
+
+      # Discover the effective set of SQL trigger files for the given connection.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @return [Array<String>] list of file paths
+      def discover_trigger_files(conn)
+        Arfi::SqlTriggerLoader.send(:sql_files, conn)
+      end
+
+      # Validate a single SQL trigger file by executing it against the database.
+      #
+      # On PostgreSQL, wraps execution in a transaction with rollback to avoid side effects.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [String] file path to the SQL file
+      # @raise [StandardError]
+      # @return [Hash] result with :file, :status, and optionally :error keys
+      def validate_sql_file(conn, file)
+        sql = File.read(file.to_s).strip
+        return { file: file, status: 'SKIP', error: 'File is empty' } if sql.empty?
+
+        execute_sql_safely(conn, sql)
+        { file: file, status: 'OK' }
+      rescue StandardError => e
+        { file: file, status: 'FAIL', error: e.message }
+      end
+
+      # Execute SQL safely inside a rollback transaction on PostgreSQL, or directly otherwise.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [String] sql SQL to execute
+      # @raise [ActiveRecord::Rollback]
+      # @return [void]
+      def execute_sql_safely(conn, sql)
+        if postgresql_adapter?(conn)
+          conn.transaction do
+            conn.execute(sql)
+            raise ActiveRecord::Rollback
+          end
+        else
+          conn.execute(sql)
+        end
+      end
+
+      # Check whether the connection is PostgreSQL.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @return [Boolean]
+      def postgresql_adapter?(conn)
+        conn.instance_of?(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+      end
+
+      # Check whether a resolved trigger exists in the database.
+      #
+      # Extracts the target table name from the SQL file to call {ActiveRecord::Base.trigger_exists?}.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] _conn
+      # @param [Hash{Symbol => Object}] row resolved trigger row from candidates
+      # @return [Hash] result with :trigger, :schema, :table, :status, :path keys
+      def doctor_check_trigger(_conn, row)
+        trigger_name = row[:trigger]
+        schema = row[:schema]
+        path = row[:path]
+        table = extract_table_from_sql(path)
+        exists = table && ActiveRecord::Base.trigger_exists?(table, trigger_name)
+
+        { trigger: trigger_name, schema: schema, status: exists ? 'OK' : 'MISSING',
+          table: table || '?', path: path }
+      end
+
+      # Parse the target table name from a CREATE TRIGGER SQL file.
+      #
+      # Extracts the identifier following the ON keyword.
+      #
+      # @private
+      # @param [String] path path to the SQL file
+      # @raise [StandardError] if file cannot be read
+      # @return [String, nil] table name or nil if parsing fails
+      def extract_table_from_sql(path)
+        sql = File.read(path.to_s)
+        match = sql.match(/ON\s+(?:\w+\.)?(\w+)/im)
+        match&.[](1)
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/lib/arfi/commands/triggers_doctor_rendering.rb
+++ b/lib/arfi/commands/triggers_doctor_rendering.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Arfi
+  module Commands
+    # Table-rendering helpers for {Arfi::Commands::TriggersDoctor}.
+    module TriggersDoctorRendering
+      private
+
+      # Render validation results in the selected output format.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def report_validate_results(results)
+        case options[:format].to_s
+        when 'json'
+          puts JSON.pretty_generate(results.map { |result| format_validate_result(result) })
+        when 'paths'
+          results.each { |result| puts "#{rel(result[:file].to_s)}  #{result[:status]}" }
+        else
+          print_validate_table(results)
+        end
+      end
+
+      # Format a validation result for JSON output.
+      #
+      # @private
+      # @param [Hash] result
+      # @return [Hash]
+      def format_validate_result(result)
+        { file: rel(result[:file].to_s), status: result[:status], error: result[:error] }.compact
+      end
+
+      # Print validation results as an ASCII table.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def print_validate_table(results)
+        cols = %w[file status error]
+        rows = build_validate_rows(results)
+        widths = calculate_col_widths(cols, rows)
+        print_separator(cols, widths)
+        rows.each do |row|
+          puts cols.map { |c| row[c.to_sym].to_s.ljust(widths[c]) }.join('  ')
+        end
+      end
+
+      # Build table rows for validate results.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [Array<Hash{Symbol => String}>]
+      def build_validate_rows(results)
+        results.map do |result| # steep:ignore
+          { file: rel(result[:file].to_s), status: result[:status], error: result[:error] || '' }
+        end
+      end
+
+      # Render doctor results in the selected output format.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def report_doctor_results(results)
+        case options[:format].to_s
+        when 'json'
+          puts JSON.pretty_generate(results)
+        when 'paths'
+          results.each { |result| puts "#{rel(result[:path].to_s)}  #{result[:status]}" }
+        else
+          print_doctor_table(results)
+        end
+      end
+
+      # Print doctor results as an ASCII table with trigger, schema, table, status, path columns.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [void]
+      def print_doctor_table(results)
+        cols = %w[trigger schema table status path]
+        rows = build_doctor_rows(results)
+        widths = calculate_col_widths(cols, rows)
+        print_separator(cols, widths)
+        rows.each do |row|
+          puts cols.map { |c| row[c.to_sym].to_s.ljust(widths[c]) }.join('  ')
+        end
+      end
+
+      # Build table rows for doctor results.
+      #
+      # @private
+      # @param [Array<Hash>] results
+      # @return [Array<Hash{Symbol => String}>]
+      def build_doctor_rows(results)
+        results.map do |result|
+          { trigger: result[:trigger], schema: result[:schema], table: result[:table],
+            status: result[:status], path: rel(result[:path].to_s) }
+        end
+      end
+
+      # Calculate column widths for the ASCII table.
+      #
+      # @private
+      # @param [Array<String>] cols column names
+      # @param [Array<Hash>] rows
+      # @return [Hash<String, Integer>]
+      def calculate_col_widths(cols, rows)
+        widths = {} # steep:ignore
+        cols.each do |c|
+          widths[c] = ([c.length] + rows.map { |r| r[c.to_sym].to_s.length }).max
+        end
+        widths
+      end
+
+      # Print the table header and separator line.
+      #
+      # @private
+      # @param [Array<String>] cols
+      # @param [Hash<String, Integer>] widths
+      # @return [void]
+      def print_separator(cols, widths)
+        puts cols.map { |c| c.ljust(widths[c]) }.join('  ')
+        puts cols.map { |c| '-' * widths[c] }.join('  ')
+      end
+    end
+  end
+end

--- a/sig/lib/arfi/commands/triggers.rbs
+++ b/sig/lib/arfi/commands/triggers.rbs
@@ -35,6 +35,12 @@ module Arfi
       # steep:ignore:end
       def list: () -> void
 
+      # steep:ignore:end
+      def validate: () -> void
+
+      # steep:ignore:end
+      def doctor: () -> void
+
       private
 
       def validate_schema_format!: () -> void

--- a/sig/lib/arfi/commands/triggers_doctor.rbs
+++ b/sig/lib/arfi/commands/triggers_doctor.rbs
@@ -1,0 +1,33 @@
+module Arfi
+  module Commands
+    module TriggersDoctor : Arfi::Commands::Triggers
+      include TriggersDoctorRendering
+
+      private
+
+      def validate: () -> void
+
+      def doctor: () -> void
+
+      def prepare_connection: () -> ::ActiveRecord::ConnectionAdapters::AbstractAdapter
+
+      def resolve_candidates: () -> Array[::Hash[Symbol, untyped]]
+
+      def establish_connection: () -> ::ActiveRecord::ConnectionAdapters::AbstractAdapter
+
+      def raise_unless_supported_adapter: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> void
+
+      def postgresql_adapter?: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> bool
+
+      def execute_sql_safely: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, String sql) -> void
+
+      def discover_trigger_files: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> Array[String]
+
+      def validate_sql_file: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, String file) -> ::Hash[Symbol, String?]
+
+      def doctor_check_trigger: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn, ::Hash[Symbol, untyped] row) -> ::Hash[Symbol, String]
+
+      def extract_table_from_sql: (String path) -> String?
+    end
+  end
+end

--- a/sig/lib/arfi/commands/triggers_doctor_rendering.rbs
+++ b/sig/lib/arfi/commands/triggers_doctor_rendering.rbs
@@ -1,0 +1,25 @@
+module Arfi
+  module Commands
+    module TriggersDoctorRendering : Arfi::Commands::Triggers
+      private
+
+      def report_validate_results: (Array[::Hash[Symbol, String?]] results) -> void
+
+      def format_validate_result: (::Hash[Symbol, String?] result) -> ::Hash[Symbol, String]
+
+      def build_validate_rows: (Array[::Hash[Symbol, String?]] results) -> Array[::Hash[Symbol, String]]
+
+      def print_validate_table: (Array[::Hash[Symbol, String?]] results) -> void
+
+      def report_doctor_results: (Array[::Hash[Symbol, String]] results) -> void
+
+      def build_doctor_rows: (Array[::Hash[Symbol, String]] results) -> Array[::Hash[Symbol, String]]
+
+      def print_doctor_table: (Array[::Hash[Symbol, String]] results) -> void
+
+      def calculate_col_widths: (Array[String] cols, Array[::Hash[Symbol, String]] rows) -> ::Hash[String, Integer]
+
+      def print_separator: (Array[String] cols, ::Hash[String, Integer] widths) -> void
+    end
+  end
+end

--- a/spec/arfi/commands/triggers_doctor_spec.rb
+++ b/spec/arfi/commands/triggers_doctor_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Arfi::Commands::Triggers, :pgsql do
+  include ArfiSpec::TmpRoot
+  include ArfiSpec::TriggerLoaderHelpers
+
+  before do
+    ActiveRecord::Base.connection.execute(<<~SQL)
+      CREATE TABLE IF NOT EXISTS arfi_users (
+        id serial PRIMARY KEY, name text
+      );
+    SQL
+    ActiveRecord::Base.connection.execute(<<~SQL)
+      CREATE OR REPLACE FUNCTION public.trg_fn()
+      RETURNS TRIGGER LANGUAGE plpgsql AS $$
+      BEGIN RETURN NEW; END;
+      $$;
+    SQL
+  end
+
+  after do
+    ActiveRecord::Base.connection.execute('DROP FUNCTION IF EXISTS public.trg_fn() CASCADE;')
+    ActiveRecord::Base.connection.execute('DROP TABLE IF EXISTS arfi_users CASCADE;')
+  end
+
+  let(:trg_sql) do
+    'CREATE TRIGGER trg BEFORE INSERT ON arfi_users FOR EACH ROW EXECUTE FUNCTION public.trg_fn();'
+  end
+
+  describe 'validate' do
+    it 'reports OK for a valid SQL trigger file' do
+      write_function('db/triggers/public/valid_trg.sql', trg_sql)
+
+      expect { described_class.start(%w[validate --adapter=postgresql --format=paths]) }
+        .to output(/OK/).to_stdout
+    end
+
+    it 'reports FAIL for invalid SQL syntax' do
+      write_function('db/triggers/public/bad_trg.sql', 'CREATE TRIGGER syntax_error ON')
+
+      expect { described_class.start(%w[validate --adapter=postgresql --format=paths]) }
+        .to output(/FAIL/).to_stdout
+    end
+
+    it 'does not leave triggers in the database after validation on PostgreSQL' do
+      write_function('db/triggers/public/transient_trg.sql', trg_sql)
+
+      described_class.start(%w[validate --adapter=postgresql --format=paths])
+
+      expect(ActiveRecord::Base.trigger_exists?('arfi_users', 'trg')).to be false
+    end
+
+    it 'reports OK via table format by default' do
+      write_function('db/triggers/public/table_trg.sql', trg_sql)
+
+      expect { described_class.start(%w[validate --adapter=postgresql]) }
+        .to output(/table_trg.+OK/).to_stdout
+    end
+
+    it 'outputs valid JSON with --format=json' do
+      write_function('db/triggers/public/json_trg.sql', trg_sql)
+
+      expect { described_class.start(%w[validate --adapter=postgresql --format=json]) }
+        .to output(/"status":\s*"OK"/).to_stdout
+    end
+  end
+
+  describe 'doctor' do
+    it 'reports OK for triggers that exist in the database' do
+      sql = 'CREATE TRIGGER existing_trg BEFORE INSERT ON arfi_users FOR EACH ROW EXECUTE FUNCTION public.trg_fn();'
+      write_function('db/triggers/public/existing_trg.sql', sql)
+      ActiveRecord::Base.connection.execute(sql)
+      expect { described_class.start(%w[doctor --adapter=postgresql --format=paths]) }.to output(/OK/).to_stdout
+    end
+
+    it 'reports MISSING for triggers not in the database' do
+      write_function('db/triggers/public/missing_trg.sql', trg_sql)
+
+      expect { described_class.start(%w[doctor --adapter=postgresql --format=paths]) }
+        .to output(/MISSING/).to_stdout
+    end
+
+    it 'outputs valid JSON with --format=json' do
+      write_function('db/triggers/public/json_doc_trg.sql', trg_sql)
+
+      expect { described_class.start(%w[doctor --adapter=postgresql --format=json]) }
+        .to output(/"status":\s*"MISSING"/).to_stdout
+    end
+
+    it 'shows the table name in doctor output' do
+      write_function('db/triggers/public/table_check_trg.sql', trg_sql)
+
+      expect { described_class.start(%w[doctor --adapter=postgresql --format=json]) }
+        .to output(/"table":\s*"arfi_users"/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `arfi triggers validate` and `arfi triggers doctor` CLI commands, mirroring the existing `arfi functions validate/doctor`

## Changes

### New files

| File                                                  | Purpose                                                                                                                                                                                   |
|-------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `lib/arfi/commands/triggers_doctor.rb`                | `validate` + `doctor` methods for triggers. Calls `SqlTriggerLoader#sql_files` for discovery, wraps PG in rollback, parses `ON <table>` from SQL for doctor checks via `trigger_exists?`. |
| `lib/arfi/commands/triggers_doctor_rendering.rb`      | ASCII table / JSON / paths rendering for both commands. Doctor table includes a `table` column.                                                                                           |
| `sig/lib/arfi/commands/triggers_doctor.rbs`           | RBS types for `TriggersDoctor`                                                                                                                                                            |
| `sig/lib/arfi/commands/triggers_doctor_rendering.rbs` | RBS types for renderer                                                                                                                                                                    |
| `spec/arfi/commands/triggers_doctor_spec.rb`          | 9 integration tests tagged `:pgsql`                                                                                                                                                       |

### Modified files

- `lib/arfi/commands/triggers.rb` — requires + includes `TriggersDoctor`, adds `validate`/`doctor` Thor proxy methods with `desc`/`option` DSL
- `sig/lib/arfi/commands/triggers.rbs` — `validate` and `doctor` method signatures

## CLI examples

```bash
# Validate all trigger SQL files against the database
bundle exec arfi triggers validate --adapter=postgresql

# Check which triggers exist in the database vs on disk
bundle exec arfi triggers doctor --adapter=postgresql --format=json
```
