### PR TITLE
[1.1.0] Added RSpec matchers

### DIFF
--- a/lib/arfi/rspec/matchers.rb
+++ b/lib/arfi/rspec/matchers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+if defined?(RSpec)
+  RSpec::Matchers.define :have_arfi_function do
+    match do |actual|
+      ActiveRecord::Base.function_exists?(actual)
+    end
+  end
+
+  RSpec::Matchers.define :have_arfi_trigger do
+    chain :on_table do |table_name|
+      @table_name = table_name
+    end
+
+    match do |actual|
+      raise ArgumentError, 'use .on_table(:table_name) chain' if @table_name.nil?
+
+      ActiveRecord::Base.trigger_exists?(@table_name, actual)
+    end
+  end
+end

--- a/sig/compat/rspec.rbs
+++ b/sig/compat/rspec.rbs
@@ -1,0 +1,11 @@
+# RSpec RBS stubs for ARFI matchers DSL
+module RSpec
+  module Matchers
+    def self.define: (Symbol name) { (?) [self: Matcher] -> void } -> void
+  end
+
+  class Matcher
+    def match: { (untyped actual) -> boolish } -> void
+    def chain: (Symbol name) { (untyped) -> void } -> void
+  end
+end

--- a/spec/arfi/rspec/matchers_spec.rb
+++ b/spec/arfi/rspec/matchers_spec.rb
@@ -5,21 +5,26 @@ require 'arfi/rspec/matchers'
 
 RSpec.describe 'ARFI RSpec matchers', :pgsql do # rubocop:disable RSpec/DescribeClass
   describe 'have_arfi_function' do
+    let(:function_name) { 'arfi_test_fn' }
+
     it 'passes when the function exists in the database' do
       ActiveRecord::Base.connection.execute(<<~SQL)
         CREATE OR REPLACE FUNCTION public.arfi_test_fn()
         RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
       SQL
 
-      expect('arfi_test_fn').to have_arfi_function
+      expect(function_name).to have_arfi_function
     end
 
     it 'fails when the function does not exist' do
-      expect('arfi_nonexistent_fn').not_to have_arfi_function
+      missing_fn = 'arfi_nonexistent_fn'
+      expect(missing_fn).not_to have_arfi_function
     end
   end
 
   describe 'have_arfi_trigger' do
+    let(:trigger_name) { 'arfi_test_trg' }
+
     it 'passes when the trigger exists on the given table' do # rubocop:disable RSpec/ExampleLength
       conn = ActiveRecord::Base.connection
       conn.execute(<<~SQL)
@@ -40,15 +45,17 @@ RSpec.describe 'ARFI RSpec matchers', :pgsql do # rubocop:disable RSpec/Describe
           EXECUTE FUNCTION public.arfi_test_trg_fn();
       SQL
 
-      expect('arfi_test_trg').to have_arfi_trigger.on_table('arfi_test_trg_users')
+      expect(trigger_name).to have_arfi_trigger.on_table('arfi_test_trg_users')
     end
 
     it 'fails when the trigger does not exist' do
-      expect('arfi_nonexistent_trg').not_to have_arfi_trigger.on_table('arfi_test_trg_users')
+      missing_trg = 'arfi_nonexistent_trg'
+      expect(missing_trg).not_to have_arfi_trigger.on_table('arfi_test_trg_users')
     end
 
     it 'raises ArgumentError when .on_table is not called' do # rubocop:disable RSpec/MultipleExpectations
-      expect { expect('any_trg').to have_arfi_trigger }
+      any_trg = 'any_trg'
+      expect { expect(any_trg).to have_arfi_trigger }
         .to raise_error(ArgumentError, /on_table/)
     end
   end

--- a/spec/arfi/rspec/matchers_spec.rb
+++ b/spec/arfi/rspec/matchers_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'arfi/rspec/matchers'
+
+RSpec.describe 'ARFI RSpec matchers', :pgsql do # rubocop:disable RSpec/DescribeClass
+  describe 'have_arfi_function' do
+    it 'passes when the function exists in the database' do
+      ActiveRecord::Base.connection.execute(<<~SQL)
+        CREATE OR REPLACE FUNCTION public.arfi_test_fn()
+        RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+      SQL
+
+      expect('arfi_test_fn').to have_arfi_function
+    end
+
+    it 'fails when the function does not exist' do
+      expect('arfi_nonexistent_fn').not_to have_arfi_function
+    end
+  end
+
+  describe 'have_arfi_trigger' do
+    it 'passes when the trigger exists on the given table' do # rubocop:disable RSpec/ExampleLength
+      conn = ActiveRecord::Base.connection
+      conn.execute(<<~SQL)
+        CREATE TABLE IF NOT EXISTS arfi_test_trg_users (
+          id serial PRIMARY KEY, name text
+        );
+      SQL
+      conn.execute(<<~SQL)
+        CREATE OR REPLACE FUNCTION public.arfi_test_trg_fn()
+        RETURNS TRIGGER LANGUAGE plpgsql AS $$
+        BEGIN RETURN NEW; END;
+        $$;
+      SQL
+      conn.execute(<<~SQL)
+        CREATE TRIGGER arfi_test_trg
+          BEFORE INSERT ON arfi_test_trg_users
+          FOR EACH ROW
+          EXECUTE FUNCTION public.arfi_test_trg_fn();
+      SQL
+
+      expect('arfi_test_trg').to have_arfi_trigger.on_table('arfi_test_trg_users')
+    end
+
+    it 'fails when the trigger does not exist' do
+      expect('arfi_nonexistent_trg').not_to have_arfi_trigger.on_table('arfi_test_trg_users')
+    end
+
+    it 'raises ArgumentError when .on_table is not called' do # rubocop:disable RSpec/MultipleExpectations
+      expect { expect('any_trg').to have_arfi_trigger }
+        .to raise_error(ArgumentError, /on_table/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add RSpec test helpers (`have_arfi_function`, `have_arfi_trigger`) for verifying database functions and triggers in test suites.

## Details

- **`have_arfi_function`** — matches when the named function exists in the database (checks `pg_proc` for PG, `information_schema.routines` for MySQL/Trilogy)
- **`have_arfi_trigger`** — matches when the named trigger exists on a given table; requires `.on_table(:table_name)` chain
- Guarded by `if defined?(RSpec)` — no-op outside test environments
- Usage: `require 'arfi/rspec/matchers'` (no railtie auto-load)

## Related Issues

Closes ARFI-10

## Checklist

- [x] Tests pass (`bundle exec rspec` — 63/0)
- [x] Linter passes (`bundle exec rubocop` — 0 offenses)
- [x] Type checker passes (`bundle exec steep check` — no errors)
- [x] Docs are up to date (`bundle exec docscribe lib spec --rbs-collection`)
