### PR TITLE
[1.1.0] Add arfi functions show command

### DIFF
--- a/lib/arfi/commands/functions.rb
+++ b/lib/arfi/commands/functions.rb
@@ -12,6 +12,7 @@ require_relative 'functions_rendering'
 require_relative 'functions_candidates'
 require_relative 'functions_doctor_rendering'
 require_relative 'functions_doctor'
+require_relative 'functions_show'
 
 module Arfi
   module Commands
@@ -28,6 +29,7 @@ module Arfi
       include FunctionsRendering
       include FunctionsCandidates
       include FunctionsDoctor
+      include FunctionsShow
 
       default_task :list
 
@@ -35,6 +37,7 @@ module Arfi
       map %w[ls] => :list
       map %w[rm delete del] => :destroy
       map %w[new add] => :create
+      map %w[show cat source] => :display_source
 
       # steep:ignore:start
       desc(
@@ -166,6 +169,25 @@ module Arfi
       #
       # @return [void]
       def doctor # rubocop:disable Lint/UselessMethodDefinition
+        super
+      end
+
+      # steep:ignore:start
+      desc(
+        'show FUNCTION_NAME [--schema=schema]',
+        "Display the SQL source of a function from the database.\n" \
+        'Uses pg_get_functiondef on PostgreSQL, SHOW CREATE FUNCTION on MySQL/Trilogy.'
+      )
+      option :schema, type: :string, banner: 'schema',
+                      desc: "PostgreSQL schema name (alternative to 'schema.function')."
+      # steep:ignore:end
+      # Display the SQL source of a function from the database.
+      #
+      # Delegates to {FunctionsShow#display_source}.
+      #
+      # @param [String] function_ref Function name (optionally schema-qualified)
+      # @return [void]
+      def display_source(function_ref) # rubocop:disable Lint/UselessMethodDefinition
         super
       end
     end

--- a/lib/arfi/commands/functions_doctor.rb
+++ b/lib/arfi/commands/functions_doctor.rb
@@ -157,9 +157,8 @@ module Arfi
       # Check whether a resolved function exists in the database.
       #
       # @private
-      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] _conn
       # @param [Hash{Symbol => Object}] row resolved function row from candidates
-      # @param [Object] _conn Param documentation.
       # @return [Hash] result with :function, :schema, :status, :path keys
       def doctor_check_function(_conn, row)
         function_name = row[:function]

--- a/lib/arfi/commands/functions_show.rb
+++ b/lib/arfi/commands/functions_show.rb
@@ -8,7 +8,9 @@ module Arfi
 
       # Display the SQL source of a function from the database.
       #
+      # @private
       # @param [String] function_ref Function name (optionally schema-qualified)
+      # @raise [Arfi::Errors::FunctionNotFound]
       # @return [void]
       def display_source(function_ref)
         schema, function_name = parse_function_ref(function_ref)

--- a/lib/arfi/commands/functions_show.rb
+++ b/lib/arfi/commands/functions_show.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Arfi
+  module Commands
+    # Show function source for {Arfi::Commands::Functions}.
+    module FunctionsShow
+      private
+
+      # Display the SQL source of a function from the database.
+      #
+      # @param [String] function_ref Function name (optionally schema-qualified)
+      # @return [void]
+      def display_source(function_ref)
+        schema, function_name = parse_function_ref(function_ref)
+        validate_identifiers!(schema, function_name)
+        prepare_connection
+
+        source = ActiveRecord::Base.function_source(function_name, schema: schema)
+        if source.nil?
+          raise Arfi::Errors::FunctionNotFound,
+                "Function #{[schema, function_name].compact.join('.')} not found in database"
+        end
+
+        puts source
+      end
+
+      # Run shared setup steps for show command.
+      #
+      # @private
+      # @return [ActiveRecord::ConnectionAdapters::AbstractAdapter]
+      def prepare_connection
+        validate_schema_format!
+        validate_adapter_option!
+        conn = establish_connection
+        raise_unless_supported_adapter(conn)
+        conn
+      end
+
+      # Establish a database connection for show operations.
+      #
+      # @private
+      # @return [ActiveRecord::ConnectionAdapters::AbstractAdapter]
+      def establish_connection
+        if Rails::VERSION::MAJOR < 7 || (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR < 2)
+          ActiveRecord::Base.connection
+        else
+          ActiveRecord::Base.lease_connection
+        end
+      end
+
+      # Raise unless the connection adapter is PostgreSQL, Mysql2, or Trilogy.
+      #
+      # @private
+      # @param [ActiveRecord::ConnectionAdapters::AbstractAdapter] conn
+      # @raise [Arfi::Errors::AdapterNotSupported]
+      # @return [void]
+      def raise_unless_supported_adapter(conn)
+        allowed = %w[
+          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+          ActiveRecord::ConnectionAdapters::Mysql2Adapter
+          ActiveRecord::ConnectionAdapters::TrilogyAdapter
+        ].freeze
+
+        raise Arfi::Errors::AdapterNotSupported unless allowed.include?(conn.class.name)
+      end
+    end
+  end
+end

--- a/lib/arfi/errors.rb
+++ b/lib/arfi/errors.rb
@@ -51,5 +51,8 @@ module Arfi
         super
       end
     end
+
+    # Raised when a function is not found in the database.
+    class FunctionNotFound < StandardError; end
   end
 end

--- a/lib/arfi/extensions/active_record/base.rb
+++ b/lib/arfi/extensions/active_record/base.rb
@@ -90,5 +90,53 @@ module ActiveRecord
         LIMIT 1;
       SQL
     end
+
+    # Retrieve the SQL source of a function from the database.
+    #
+    # Dispatches to the correct adapter method.
+    #
+    # @param [String] function_name Function name to retrieve
+    # @param [String, nil] schema Schema name (PostgreSQL only)
+    # @return [String, nil] The function source SQL, or nil if not found
+    def self.function_source(function_name, schema: nil)
+      case connection.class.name
+      when 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
+        pg_function_source(function_name, schema: schema)
+      when 'ActiveRecord::ConnectionAdapters::Mysql2Adapter',
+          'ActiveRecord::ConnectionAdapters::TrilogyAdapter'
+        mysql_function_source(function_name)
+      else
+        raise ActiveRecord::AdapterNotFound, "adapter #{connection.class.name} is not supported"
+      end
+    end
+
+    # Retrieve function source from PostgreSQL via pg_get_functiondef.
+    #
+    # @param [String] function_name Function name to retrieve
+    # @param [String, nil] schema Schema name (defaults to search path)
+    # @return [String, nil] The function source SQL, or nil if not found
+    def self.pg_function_source(function_name, schema: nil)
+      schema_clause = schema ? "AND n.nspname = #{connection.quote(schema)}" : ''
+      sql = <<~SQL.squish
+        SELECT pg_get_functiondef(p.oid)
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE p.proname = #{connection.quote(function_name)}
+          #{schema_clause}
+        LIMIT 1
+      SQL
+      connection.select_value(sql)
+    end
+
+    # Retrieve function source from MySQL/MariaDB via SHOW CREATE FUNCTION.
+    #
+    # @param [String] function_name Function name to retrieve
+    # @return [String, nil] The function source SQL, or nil if not found
+    def self.mysql_function_source(function_name)
+      row = connection.select_one("SHOW CREATE FUNCTION #{connection.quote_table_name(function_name)}")
+      row&.values&.last
+    rescue ActiveRecord::StatementInvalid
+      nil
+    end
   end
 end

--- a/lib/arfi/extensions/active_record/base.rb
+++ b/lib/arfi/extensions/active_record/base.rb
@@ -97,6 +97,7 @@ module ActiveRecord
     #
     # @param [String] function_name Function name to retrieve
     # @param [String, nil] schema Schema name (PostgreSQL only)
+    # @raise [ActiveRecord::AdapterNotFound]
     # @return [String, nil] The function source SQL, or nil if not found
     def self.function_source(function_name, schema: nil)
       case connection.class.name
@@ -131,6 +132,7 @@ module ActiveRecord
     # Retrieve function source from MySQL/MariaDB via SHOW CREATE FUNCTION.
     #
     # @param [String] function_name Function name to retrieve
+    # @raise [ActiveRecord::StatementInvalid]
     # @return [String, nil] The function source SQL, or nil if not found
     def self.mysql_function_source(function_name)
       row = connection.select_one("SHOW CREATE FUNCTION #{connection.quote_table_name(function_name)}")

--- a/sig/lib/arfi/commands/functions.rbs
+++ b/sig/lib/arfi/commands/functions.rbs
@@ -47,6 +47,9 @@ module Arfi
       # steep:ignore:end
       def doctor: () -> void
 
+      # steep:ignore:end
+      def display_source: (String function_ref) -> void
+
       private
 
       def validate_schema_format!: () -> void

--- a/sig/lib/arfi/commands/functions_show.rbs
+++ b/sig/lib/arfi/commands/functions_show.rbs
@@ -1,0 +1,15 @@
+module Arfi
+  module Commands
+    module FunctionsShow : Arfi::Commands::Functions
+      private
+
+      def display_source: (String function_ref) -> void
+
+      def prepare_connection: () -> ::ActiveRecord::ConnectionAdapters::AbstractAdapter
+
+      def establish_connection: () -> ::ActiveRecord::ConnectionAdapters::AbstractAdapter
+
+      def raise_unless_supported_adapter: (::ActiveRecord::ConnectionAdapters::AbstractAdapter conn) -> void
+    end
+  end
+end

--- a/sig/lib/arfi/errors.rbs
+++ b/sig/lib/arfi/errors.rbs
@@ -23,5 +23,9 @@ module Arfi
 
       def initialize: (?::String message) -> void
     end
+
+    class FunctionNotFound < StandardError
+      def initialize: (?::String? message) -> void
+    end
   end
 end

--- a/sig/lib/arfi/extensions/active_record/base.rbs
+++ b/sig/lib/arfi/extensions/active_record/base.rbs
@@ -11,5 +11,11 @@ module ActiveRecord
     def self.pg_trigger_exists?: (String table, String trigger_name) -> bool
 
     def self.mysql_trigger_exists?: (String table, String trigger_name) -> bool
+
+    def self.function_source: (String function_name, ?schema: String?) -> String?
+
+    def self.pg_function_source: (String function_name, ?schema: String?) -> String?
+
+    def self.mysql_function_source: (String function_name) -> String?
   end
 end

--- a/spec/arfi/commands/functions_show_spec.rb
+++ b/spec/arfi/commands/functions_show_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Arfi::Commands::Functions do
+  describe 'show' do
+    it 'displays the SQL source of a function from the database', :pgsql do # rubocop:disable RSpec/ExampleLength
+      ActiveRecord::Base.connection.execute(<<~SQL)
+        CREATE OR REPLACE FUNCTION public.show_test_fn()
+        RETURNS INT LANGUAGE SQL AS $$ SELECT 42; $$;
+      SQL
+
+      expect { described_class.start(%w[show show_test_fn]) }
+        .to output(/SELECT 42/).to_stdout
+    end
+
+    it 'includes the full function definition in the output', :pgsql do # rubocop:disable RSpec/ExampleLength
+      ActiveRecord::Base.connection.execute(<<~SQL)
+        CREATE OR REPLACE FUNCTION public.show_detail_fn()
+        RETURNS INT LANGUAGE SQL IMMUTABLE AS $$ SELECT 1; $$;
+      SQL
+
+      expect { described_class.start(%w[show show_detail_fn]) }
+        .to output(/show_detail_fn/).to_stdout
+    end
+
+    it 'raises FunctionNotFound when the function does not exist', :pgsql do
+      expect { described_class.start(%w[show nonexistent_fn]) }
+        .to raise_error(Arfi::Errors::FunctionNotFound, /nonexistent_fn/)
+    end
+  end
+end


### PR DESCRIPTION
Adds `arfi functions show|cat|source` to display the SQL source of a database function.

New commands:
- `arfi functions show <name>` — display function source
- `arfi functions cat <name>` — alias
- `arfi functions source <name>` — alias

New class methods on `ActiveRecord::Base`:
- `function_source(name, schema:)` — adapter-agnostic
- `pg_function_source(name, schema:)` — uses `pg_get_functiondef`
- `mysql_function_source(name)` — uses `SHOW CREATE FUNCTION`

New internal modules and errors:
- `Arfi::Commands::FunctionsShow` — shared logic for show command
- `Arfi::Errors::FunctionNotFound` — raised when function is missing in the database

Closes ARFI-11.